### PR TITLE
DM-29030: Switch from bin_slop to brute for tests

### DIFF
--- a/python/lsst/faro/utils/tex.py
+++ b/python/lsst/faro/utils/tex.py
@@ -35,7 +35,7 @@ def correlation_function_ellipticity_from_matches(matches, **kwargs):
 def correlation_function_ellipticity(ra, dec, e1_res, e2_res,
                                      nbins=20, min_sep=0.25, max_sep=20,
                                      sep_units='arcmin', verbose=False,
-                                     bin_slop=None):
+                                     brute=False):
     """Compute shear-shear correlation function from ra, dec, g1, g2.
     Default parameters for nbins, min_sep, max_sep chosen to cover
        an appropriate range to calculate TE1 (<=1 arcmin) and TE2 (>=5 arcmin).
@@ -60,12 +60,9 @@ def correlation_function_ellipticity(ra, dec, e1_res, e2_res,
     verbose : bool
         Request verbose output from `treecorr`.
         verbose=True will use verbose=2 for `treecorr.GGCorrelation`.
-    bin_slop : float
-        If specified, this allows tuning of how `treecorr` chooses bins.
-        The value should be between 0 and 1.  Higher values allow more
-        slop, but are faster.  If not specified, treecorr will compute
-        an appropriate value.  For non-zero values, details of results
-        may not agree between runs on different architectures.
+    brute : bool
+        Use burte force mechanism.  This is very slow, but will prevent
+        cross platform inconsistencies due to numerical/digital noise
     Returns
     -------
     r, xip, xip_err : each a np.array(dtype=float)
@@ -81,14 +78,10 @@ def correlation_function_ellipticity(ra, dec, e1_res, e2_res,
 
     catTree = treecorr.Catalog(ra=ra, dec=dec, g1=e1_res, g2=e2_res,
                                dec_units='radian', ra_units='radian')
-    if bin_slop is not None:
-        gg = treecorr.GGCorrelation(nbins=nbins, min_sep=min_sep, max_sep=max_sep,
-                                    sep_units=sep_units, verbose=verbose_level,
-                                    bin_slop=bin_slop)
-    else:
-        gg = treecorr.GGCorrelation(nbins=nbins, min_sep=min_sep, max_sep=max_sep,
-                                    sep_units=sep_units,
-                                    verbose=verbose_level)
+    gg = treecorr.GGCorrelation(nbins=nbins, min_sep=min_sep, max_sep=max_sep,
+                                sep_units=sep_units,
+                                verbose=verbose_level,
+                                brute=brute)
     gg.process(catTree)
     r = np.exp(gg.meanlogr) * u.arcmin
     xip = gg.xip * u.Unit('')

--- a/tests/test_tex_util.py
+++ b/tests/test_tex_util.py
@@ -53,8 +53,8 @@ class TEXUtilTest(unittest.TestCase):
 
     def test_correlation_function_ellipticity(self):
         """Test correlation function calculation."""
-        expected_r = 4.394963986052715*u.arcmin
-        expected_xip = 0.00127  # The reduced precision is being looked at: DM-29030
+        expected_r = 4.3949517357518655*u.arcmin
+        expected_xip = 0.001269272699700824
         expected_xip_err = 0.0004931737255066678
 
         cat = self.load_data()
@@ -66,7 +66,7 @@ class TEXUtilTest(unittest.TestCase):
         e1_res = matches.aggregate(medianEllipticity1ResidualsFromCat)
         e2_res = matches.aggregate(medianEllipticity2ResidualsFromCat)
 
-        result = correlation_function_ellipticity(ra, dec, e1_res, e2_res, bin_slop=0)
+        result = correlation_function_ellipticity(ra, dec, e1_res, e2_res, brute=True)
         self.assertTrue(u.isclose(np.mean(result[0]), expected_r))
         self.assertTrue(u.isclose(np.mean(result[1]), expected_xip, atol=0.00001*u.dimensionless_unscaled))
         self.assertTrue(u.isclose(np.mean(result[2]), expected_xip_err))


### PR DESCRIPTION
The brute option will make answers the same across platforms,
but is too slow to use for metric measurements