### PR TITLE
Change default calibs to FGCM/jointcal.

### DIFF
--- a/pipelines/preparation/preparation_matched.yaml
+++ b/pipelines/preparation/preparation_matched.yaml
@@ -1,4 +1,12 @@
 description: Produce matched catalogs
 tasks:
-  matchCatalogsPatch: lsst.faro.preparation.PatchMatchedPreparationTask
-  matchCatalogsTract: lsst.faro.preparation.TractMatchedPreparationTask
+  matchCatalogsPatch:
+    class: lsst.faro.preparation.PatchMatchedPreparationTask
+    config:
+      connections.photoCalibName: fgcm_photoCalib
+      apply_external_wcs: True  # We only support jointcal for now
+  matchCatalogsTract:
+    class: lsst.faro.preparation.TractMatchedPreparationTask
+    config:
+      connections.photoCalibName: fgcm_photoCalib
+      apply_external_wcs: True  # We only support jointcal for now

--- a/pipelines/preparation/preparation_matched_multi.yaml
+++ b/pipelines/preparation/preparation_matched_multi.yaml
@@ -1,3 +1,7 @@
 description: Produce multiband matched catalogs
 tasks:
-  matchCatalogPatchMultiBand: lsst.faro.preparation.PatchMatchedMultiBandPreparationTask
+  matchCatalogsPatchMultiBand:
+    class: lsst.faro.preparation.PatchMatchedMultiBandPreparationTask
+    config:
+      connections.photoCalibName: fgcm_photoCalib
+      apply_external_wcs: True  # We only support jointcal for now


### PR DESCRIPTION
I _think_ that only two pipelines needed updating to use jointcal/FGCM. But it's quite possible I missed something. 

Note also that the subtask names in the pipelines were previously using `matchCatalogX` sometimes and `matchCatalogsX` other times, so I made them consistent (I chose `matchCatalogs`). 