### PR TITLE
Allow for non-overridden pipeline

### DIFF
--- a/pipelines/metrics_pipeline_matched_jointcal_fgcm.yaml
+++ b/pipelines/metrics_pipeline_matched_jointcal_fgcm.yaml
@@ -1,0 +1,5 @@
+description: Full matched metrics pipeline
+imports:
+  - location: $FARO_DIR/pipelines/preparation/preparation_matched_jointcal_fgcm.yaml
+  - location: $FARO_DIR/pipelines/measurement/measurement_matched.yaml
+  - location: $FARO_DIR/pipelines/summary/summary_matched.yaml

--- a/pipelines/preparation/preparation_matched.yaml
+++ b/pipelines/preparation/preparation_matched.yaml
@@ -2,11 +2,5 @@ description: Produce matched catalogs
 tasks:
   matchCatalogsPatch:
     class: lsst.faro.preparation.PatchMatchedPreparationTask
-    config:
-      connections.photoCalibName: fgcm_photoCalib
-      apply_external_wcs: True  # We only support jointcal for now
   matchCatalogsTract:
     class: lsst.faro.preparation.TractMatchedPreparationTask
-    config:
-      connections.photoCalibName: fgcm_photoCalib
-      apply_external_wcs: True  # We only support jointcal for now


### PR DESCRIPTION
This replaces the pipeline that doesn't need jointcal or FGCM