### PR TITLE
Tickets/dm 29933: Add base classes for single-detector source catalog metrics

### DIFF
--- a/pipelines/measurement/measurement_detector.yaml
+++ b/pipelines/measurement/measurement_detector.yaml
@@ -1,0 +1,15 @@
+description: Compute metrics from detector catalogs
+tasks:
+  nsrcMeasDetector:
+    class: lsst.faro.measurement.DetectorMeasurementTask
+    config:
+      connections.package: info
+      connections.metric: nsrcMeasDetector
+      python: |
+        from lsst.faro.base import NumSourcesTask
+        config.measure.retarget(NumSourcesTask)
+        config.measure.doPrimary = True       
+        config.doApplyExternalPhotoCalib = True
+        config.useGlobalExternalPhotoCalib = True
+        config.doApplyExternalSkyWcs = True
+        config.useGlobalExternalSkyWcs = False

--- a/python/lsst/faro/base/BaseSubTasks.py
+++ b/python/lsst/faro/base/BaseSubTasks.py
@@ -9,15 +9,22 @@ from lsst.faro.utils.matcher import mergeCatalogs
 __all__ = ('NumSourcesTask', 'NumSourcesMergeTask',
            'NumpySummaryTaskConfig', 'NumpySummaryTask')
 
+class NumSourcesTaskConfig(Config):
+    doPrimary = Field(doc="Only count sources where detect_isPrimary is True.",
+                      dtype=bool, default=False)
 
 class NumSourcesTask(Task):
 
-    ConfigClass = Config
+    ConfigClass = NumSourcesTaskConfig
     _DefaultName = "numSourcesTask"
 
     def run(self, catalog, metric_name, vIds=None):
         self.log.info(f"Measuring {metric_name}")
-        nSources = len(catalog)
+        if self.config.doPrimary:
+            nSources = np.sum(catalog['detect_isPrimary'] == True)
+        else:
+            nSources = len(catalog)
+        print('nSources = %i'%(nSources))
         meas = Measurement("nsrcMeas", nSources * u.count)
         return Struct(measurement=meas)
 

--- a/python/lsst/faro/base/BaseSubTasks.py
+++ b/python/lsst/faro/base/BaseSubTasks.py
@@ -9,9 +9,11 @@ from lsst.faro.utils.matcher import mergeCatalogs
 __all__ = ('NumSourcesTask', 'NumSourcesMergeTask',
            'NumpySummaryTaskConfig', 'NumpySummaryTask')
 
+
 class NumSourcesTaskConfig(Config):
     doPrimary = Field(doc="Only count sources where detect_isPrimary is True.",
                       dtype=bool, default=False)
+
 
 class NumSourcesTask(Task):
 
@@ -21,7 +23,7 @@ class NumSourcesTask(Task):
     def run(self, catalog, metric_name, vIds=None):
         self.log.info(f"Measuring {metric_name}")
         if self.config.doPrimary:
-            nSources = np.sum(catalog['detect_isPrimary'] == True)
+            nSources = np.sum(catalog['detect_isPrimary'] is True)
         else:
             nSources = len(catalog)
         print('nSources = %i'%(nSources))

--- a/python/lsst/faro/measurement/DetectorMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorMeasurement.py
@@ -1,0 +1,33 @@
+import lsst.pipe.base as pipeBase
+from lsst.verify.tasks import MetricConnections
+
+from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
+
+__all__ = ("DetectorMeasurementTaskConfig", "DetectorMeasurementTask")
+
+
+class DetectorMeasurementTaskConnections(MetricConnections,
+                                         dimensions=("instrument", "visit", "detector", "band"),
+                                         defaultTemplates={"photoCalibName": "calexp.photoCalib",
+                                                           "wcsName": "calexp.wcs"}):
+
+    catalog = pipeBase.connectionTypes.Input(doc="Source catalog.",
+                                             dimensions=("instrument", "visit", "detector", "band"),
+                                             storageClass="SourceCatalog",
+                                             name="src")
+
+    measurement = pipeBase.connectionTypes.Output(doc="Per-detector measurement.",
+                                                  dimensions=("instrument", "visit", "detector", "band"),
+                                                  storageClass="MetricValue",
+                                                  name="metricvalue_{package}_{metric}")
+
+class DetectorMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
+                                    pipelineConnections=DetectorMeasurementTaskConnections):
+    pass
+
+class DetectorMeasurementTask(CatalogMeasurementBaseTask):
+    ConfigClass = DetectorMeasurementTaskConfig
+    _DefaultName = "detectorMeasurementTask"
+
+    def run(self, catalog):
+        return self.measure.run(catalog, self.config.connections.metric)

--- a/python/lsst/faro/measurement/DetectorMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorMeasurement.py
@@ -1,5 +1,6 @@
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections
+import lsst.pex.config as pexConfig
 
 from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
 
@@ -9,25 +10,76 @@ __all__ = ("DetectorMeasurementTaskConfig", "DetectorMeasurementTask")
 class DetectorMeasurementTaskConnections(MetricConnections,
                                          dimensions=("instrument", "visit", "detector", "band"),
                                          defaultTemplates={"photoCalibName": "calexp.photoCalib",
+                                                           "externalPhotoCalibName": "fgcm",
                                                            "wcsName": "calexp.wcs"}):
 
-    catalog = pipeBase.connectionTypes.Input(doc="Source catalog.",
-                                             dimensions=("instrument", "visit", "detector", "band"),
-                                             storageClass="SourceCatalog",
-                                             name="src")
+    catalog = pipeBase.connectionTypes.Input(
+        doc="Source catalog.",
+        dimensions=("instrument", "visit", "detector", "band"),
+        storageClass="SourceCatalog",
+        name="src"
+    )
+    photoCalib = pipeBase.connectionTypes.Input(
+        doc="Photometric calibration object.",
+        dimensions=("instrument", "visit", "detector", "band"),
+        storageClass="PhotoCalib",
+        name="{photoCalibName}"
+    )
+    #externalPhotoCalibTractCatalog = pipeBase.connectionTypes.Input(
+    #    doc=("Per-tract, per-visit photometric calibrations.  These catalogs use the "
+    #         "detector id for the catalog id, sorted on id for fast lookup."),
+    #    name="{externalPhotoCalibName}PhotoCalibCatalog",
+    #    storageClass="ExposureCatalog",
+    #    dimensions=("instrument", "visit", "tract", "band"),
+    #)
+    externalPhotoCalibGlobalCatalog = pipeBase.connectionTypes.Input(
+        doc=("Per-visit photometric calibrations computed globally (with no tract "
+             "information).  These catalogs use the detector id for the catalog id, "
+             "sorted on id for fast lookup."),
+        name="{externalPhotoCalibName}PhotoCalibCatalog",
+        storageClass="ExposureCatalog",
+        dimensions=("instrument", "visit", "band"),
+    )
+    measurement = pipeBase.connectionTypes.Output(
+        doc="Per-detector measurement.",
+        dimensions=("instrument", "visit", "detector", "band"),
+        storageClass="MetricValue",
+        name="metricvalue_{package}_{metric}"
+    )
 
-    measurement = pipeBase.connectionTypes.Output(doc="Per-detector measurement.",
-                                                  dimensions=("instrument", "visit", "detector", "band"),
-                                                  storageClass="MetricValue",
-                                                  name="metricvalue_{package}_{metric}")
+    def __init__(self, *, config=None):
+        super().__init__(config=config)
+        if config.doApplyExternalPhotoCalib:
+            self.inputs.remove("photoCalib")
+        else:
+            self.inputs.remove("externalPhotoCalibGlobalCatalog")
+
 
 class DetectorMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
                                     pipelineConnections=DetectorMeasurementTaskConnections):
-    pass
+    doApplyExternalPhotoCalib = pexConfig.Field(doc="Whether or not to use the external photoCalib.", 
+                                                dtype=bool, default=False)
+
 
 class DetectorMeasurementTask(CatalogMeasurementBaseTask):
     ConfigClass = DetectorMeasurementTaskConfig
     _DefaultName = "detectorMeasurementTask"
 
-    def run(self, catalog):
+    def run(self, catalog, photoCalib):
         return self.measure.run(catalog, self.config.connections.metric)
+
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        inputs = butlerQC.get(inputRefs)
+        if self.config.doApplyExternalPhotoCalib:
+            detector = inputRefs.catalog.dataId['detector']
+            externalPhotoCalibGlobalCatalog = inputs.pop('externalPhotoCalibGlobalCatalog')
+            row = externalPhotoCalibGlobalCatalog.find(detector)
+            externalPhotoCalib = row.getPhotoCalib()
+            inputs['photoCalib'] = externalPhotoCalib
+        outputs = self.run(**inputs)
+        if outputs.measurement is not None:
+            butlerQC.put(outputs, outputRefs)
+        else:
+            self.log.debugf("Skipping measurement of {!r} on {} "
+                            "as not applicable.", self, inputRefs)
+        

--- a/python/lsst/faro/measurement/DetectorMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorMeasurement.py
@@ -52,7 +52,7 @@ class DetectorMeasurementTaskConnections(MetricConnections,
              "detector id for the catalog id, sorted on id for fast lookup."),
         name="{externalPhotoCalibName}PhotoCalibCatalog",
         storageClass="ExposureCatalog",
-        dimensions=("instrument", "visit", "tract", "band"),
+        dimensions=("instrument", "visit", "tract"),
     )
     externalPhotoCalibGlobalCatalog = pipeBase.connectionTypes.Input(
         doc=("Per-visit photometric calibrations computed globally (with no tract "
@@ -60,7 +60,7 @@ class DetectorMeasurementTaskConnections(MetricConnections,
              "sorted on id for fast lookup."),
         name="{externalPhotoCalibName}PhotoCalibCatalog",
         storageClass="ExposureCatalog",
-        dimensions=("instrument", "visit", "band"),
+        dimensions=("instrument", "visit"),
     )
     measurement = pipeBase.connectionTypes.Output(
         doc="Per-detector measurement.",

--- a/python/lsst/faro/measurement/DetectorMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorMeasurement.py
@@ -91,13 +91,13 @@ class DetectorMeasurementTaskConnections(MetricConnections,
 
 class DetectorMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
                                     pipelineConnections=DetectorMeasurementTaskConnections):
-    doApplyExternalSkyWcs = pexConfig.Field(doc="Whether or not to use the external wcs.", 
+    doApplyExternalSkyWcs = pexConfig.Field(doc="Whether or not to use the external wcs.",
                                             dtype=bool, default=False)
-    useGlobalExternalSkyWcs = pexConfig.Field(doc="Whether or not to use the global external wcs.", 
+    useGlobalExternalSkyWcs = pexConfig.Field(doc="Whether or not to use the global external wcs.",
                                               dtype=bool, default=False)
-    doApplyExternalPhotoCalib = pexConfig.Field(doc="Whether or not to use the external photoCalib.", 
+    doApplyExternalPhotoCalib = pexConfig.Field(doc="Whether or not to use the external photoCalib.",
                                                 dtype=bool, default=False)
-    useGlobalExternalPhotoCalib = pexConfig.Field(doc="Whether or not to use the global external photoCalib.", 
+    useGlobalExternalPhotoCalib = pexConfig.Field(doc="Whether or not to use the global external photoCalib.",
                                                   dtype=bool, default=False)
 
 
@@ -135,4 +135,3 @@ class DetectorMeasurementTask(CatalogMeasurementBaseTask):
         else:
             self.log.debugf("Skipping measurement of {!r} on {} "
                             "as not applicable.", self, inputRefs)
-        

--- a/python/lsst/faro/measurement/__init__.py
+++ b/python/lsst/faro/measurement/__init__.py
@@ -5,6 +5,7 @@ from .PatchMeasurementTasks import *
 from .VisitMeasurementTasks import *
 from .TractMeasurementTasks import *
 from .MatchedCatalogMeasurement import *
+from .DetectorMeasurement import *
 from .VisitMeasurement import *
 from .TractMeasurement import *
 from .PatchMeasurement import *


### PR DESCRIPTION
This is the renamed branch of `u/kbechtol/calib_exploration` to add base classes for single-detector source catalog metrics. Remember to remove the `u/kbechtol/calib_exploration` branch.

These new base classes use the new Gen3 convention per-visit calibration files from FGCM and jointcal.