### PR TITLE
Update unittest expected values for TEx default column change

### DIFF
--- a/tests/data/TE1_expected_0_i.yaml
+++ b/tests/data/TE1_expected_0_i.yaml
@@ -8,4 +8,4 @@ identifier: cb5f325dc52f4ef794b3165b406c6fa4
 metric: TE1
 notes: {}
 unit: ''
-value: 0.0005146044101963828
+value: 9.517637187446586e-05

--- a/tests/test_taskConfigs.py
+++ b/tests/test_taskConfigs.py
@@ -129,8 +129,8 @@ class ConfigTest(unittest.TestCase):
         expected.nbins = 100
         expected.rhoStat = 2
         expected.shearConvention = True
-        expected.columnPsf = 'base_SdssShape_psf'
-        expected.column = 'base_SdssShape'
+        expected.columnPsf = 'ext_shapeHSM_HsmPsfMoments'
+        expected.column = 'ext_shapeHSM_HsmSourceMoments'
         task = TExTask(config=expected)
         self.check_config(task, expected, default, field_list)
 


### PR DESCRIPTION
This PR updates the unittest expected values to reflect the change in default column choices for ellipticity residual correlation measurements. 

These updates were intended to have been included in this earlier PR: https://github.com/lsst/faro/pull/89