### PR TITLE
DM-26214: Switch to using sourceTable_visit parquet files instead of src FITS files

### DIFF
--- a/pipelines/measurement/measurement_detector_table.yaml
+++ b/pipelines/measurement/measurement_detector_table.yaml
@@ -1,0 +1,12 @@
+description: Compute per-detector metrics from sourceTable_visit catalogs
+tasks:
+  nsrcMeasDetectorTable:
+    class: lsst.faro.measurement.DetectorTableMeasurementTask
+    config:
+      connections.package: info
+      connections.metric: nsrcMeasDetectorTable
+      #connections.refDataset: 'gaia_dr2_20200414'
+      connections.refDataset: 'ps1_pv3_3pi_20170110'
+      python: |
+        from lsst.faro.base import NumSourcesTask
+        config.measure.retarget(NumSourcesTask)

--- a/pipelines/measurement/measurement_detector_table.yaml
+++ b/pipelines/measurement/measurement_detector_table.yaml
@@ -5,10 +5,11 @@ tasks:
     config:
       connections.package: info
       connections.metric: nsrcMeasDetectorTable
+      # Reference dataset must be consistently specified 
+      # in connections and reference object loader.
       # Example reference datasets include: 
       # - Gaia (gaia_dr2_20200414)
       # - PS1 (ps1_pv3_3pi_20170110)
-      connections.refDataset: 'gaia_dr2_20200414'
       python: |
         from lsst.faro.base import NumSourcesTask
         config.measure.retarget(NumSourcesTask)

--- a/pipelines/measurement/measurement_detector_table.yaml
+++ b/pipelines/measurement/measurement_detector_table.yaml
@@ -5,8 +5,10 @@ tasks:
     config:
       connections.package: info
       connections.metric: nsrcMeasDetectorTable
-      #connections.refDataset: 'gaia_dr2_20200414'
-      connections.refDataset: 'ps1_pv3_3pi_20170110'
+      # Example reference datasets include: 
+      # - Gaia (gaia_dr2_20200414)
+      # - PS1 (ps1_pv3_3pi_20170110)
+      connections.refDataset: 'gaia_dr2_20200414'
       python: |
         from lsst.faro.base import NumSourcesTask
         config.measure.retarget(NumSourcesTask)

--- a/pipelines/measurement/measurement_detector_table.yaml
+++ b/pipelines/measurement/measurement_detector_table.yaml
@@ -7,9 +7,29 @@ tasks:
       connections.metric: nsrcMeasDetectorTable
       # Reference dataset must be consistently specified 
       # in connections and reference object loader.
-      # Example reference datasets include: 
+      # Reference datasets include:
       # - Gaia (gaia_dr2_20200414)
       # - PS1 (ps1_pv3_3pi_20170110)
+      # Examples to specify the reference dataset:
+      # connections.refDataset: 'gaia_dr2_20200414'
+      # connections.refDataset: 'ps1_pv3_3pi_20170110'
       python: |
         from lsst.faro.base import NumSourcesTask
         config.measure.retarget(NumSourcesTask)
+        # Example configuration to apply proper motions for Gaia
+        # config.referenceCatalogLoader.refObjLoader.ref_dataset_name = 'gaia_dr2_20200414'
+        # config.referenceCatalogLoader.refObjLoader.requireProperMotion = True
+        # config.referenceCatalogLoader.refObjLoader.anyFilterMapsToThis = 'phot_g_mean'
+        # config.referenceCatalogLoader.doApplyColorTerms = False
+        # Example configuration to apply color terms from PS1 to HSC
+        # config.referenceCatalogLoader.refObjLoader.ref_dataset_name = 'ps1_pv3_3pi_20170110'
+        # config.referenceCatalogLoader.doApplyColorTerms = True
+        # config.referenceCatalogLoader.refObjLoader.anyFilterMapsToThis = None
+        # import os
+        # from lsst.utils import getPackageDir
+        # config.referenceCatalogLoader.refObjLoader.load(os.path.join(getPackageDir('obs_subaru'),
+        #                                                              'config',
+        #                                                              'filterMap.py'))
+        # config.referenceCatalogLoader.colorterms.load(os.path.join(getPackageDir('obs_subaru'),
+        #                                                            'config',
+        #                                                            'colorterms.py'))

--- a/pipelines/measurement/measurement_visit_table.yaml
+++ b/pipelines/measurement/measurement_visit_table.yaml
@@ -1,0 +1,10 @@
+description: Compute metrics from sourceTable_visit catalogs
+tasks:
+  nsrcMeasVisitTable:
+    class: lsst.faro.measurement.VisitTableMeasurementTask
+    config:
+      connections.package: info
+      connections.metric: nsrcMeasVisitTable
+      python: |
+        from lsst.faro.base import NumSourcesTask
+        config.measure.retarget(NumSourcesTask)

--- a/python/lsst/faro/base/BaseSubTasks.py
+++ b/python/lsst/faro/base/BaseSubTasks.py
@@ -16,6 +16,7 @@ class NumSourcesTaskConfig(Config):
 
 
 class NumSourcesTask(Task):
+    """Simple default task count the number of sources/objects in catalog."""
 
     ConfigClass = NumSourcesTaskConfig
     _DefaultName = "numSourcesTask"
@@ -36,7 +37,7 @@ class NumSourcesMergeTask(Task):
     ConfigClass = Config
     _DefaultName = "numSourcesMergeTask"
 
-    def run(self, metricName, catalogs, photoCalibs, astromCalibs, dataIds):
+    def run(self, metricName, catalogs, photoCalibs, astromCalibs, **kwargs):
         self.log.info("Measuring %s", metricName)
         catalog = mergeCatalogs(catalogs, photoCalibs, astromCalibs)
         nSources = len(catalog)

--- a/python/lsst/faro/base/BaseSubTasks.py
+++ b/python/lsst/faro/base/BaseSubTasks.py
@@ -20,8 +20,8 @@ class NumSourcesTask(Task):
     ConfigClass = NumSourcesTaskConfig
     _DefaultName = "numSourcesTask"
 
-    def run(self, catalog, metric_name, vIds=None):
-        self.log.info("Measuring %s", metric_name)
+    def run(self, metricName, catalog, **kwargs):
+        self.log.info("Measuring %s", metricName)
         if self.config.doPrimary:
             nSources = np.sum(catalog['detect_isPrimary'] is True)
         else:

--- a/python/lsst/faro/base/CatalogMeasurementBase.py
+++ b/python/lsst/faro/base/CatalogMeasurementBase.py
@@ -91,33 +91,37 @@ class CatalogMeasurementBaseTask(MetricTask):
     def run(self, catalog, **kwargs):
         return self.measure.run(self.config.connections.metric, catalog, **kwargs)
 
-    def getReferenceCatalog(self, butlerQC, inputRefs, refCats, filterList, epoch=None):
+    def _getReferenceCatalog(self, butlerQC, dataIds, refCats, filterList, epoch=None):
         """Load reference catalog in sky region of interest.
 
         Parameters
         ----------
-        butlerQC :
-            Doc
-        inputRefs:
-            Doc
-        refCats:
-            Doc
+        butlerQC : `lsst.pipe.base.butlerQuantumContext.ButlerQuantumContext`
+            Butler quantum context for a Gen3 repository.
+        dataIds: interable of `lsst.daf.butler.dataId`
+             An iterable object of dataIds that point to reference catalogs
+             in a Gen3 repository.
+        refCats : iterable of `lsst.daf.butler.DeferredDatasetHandle`
+            An iterable object of dataset refs for reference catalogs in
+            a Gen3 repository.
         filterList : `list` [`str`]
             List of camera physicalFilter names to apply color terms.
+        epoch : `astropy.time.Time`, optional
+            Epoch to which to correct proper motion and parallax
+            (if available), or `None` to not apply such corrections.
 
         Returns
         -------
         refCat : `numpy.ndarray`
-            Reference catalog with color terms and proper motions optionally applied.
+            Reference catalog with color terms and proper motions
+            (optionally) applied.
         """
-
         center = lsst.geom.SpherePoint(butlerQC.quantum.dataId.region.getBoundingCircle().getCenter())
         radius = butlerQC.quantum.dataId.region.getBoundingCircle().getOpeningAngle()
 
         loaderTask = LoadReferenceCatalogTask(
             config=self.config.referenceCatalogLoader,
-            dataIds=[ref.datasetRef.dataId
-                     for ref in inputRefs.refCat],
+            dataIds=dataIds,
             refCats=refCats)
 
         # Get catalog with proper motion and color terms applied

--- a/python/lsst/faro/base/CatalogMeasurementBase.py
+++ b/python/lsst/faro/base/CatalogMeasurementBase.py
@@ -112,8 +112,10 @@ class CatalogMeasurementBaseTask(MetricTask):
 
         Returns
         -------
-        refCat : `numpy.ndarray`
-            Reference catalog with color terms and proper motions
+        refCat : `lsst.afw.table.SimpleCatalog`
+            Catalog of reference objects from region.
+        refCatCorrected : `numpy.ndarray`
+            Catalog of reference objects with proper motions and color terms
             (optionally) applied.
         """
         center = lsst.geom.SpherePoint(butlerQC.quantum.dataId.region.getBoundingCircle().getCenter())
@@ -133,9 +135,6 @@ class CatalogMeasurementBaseTask(MetricTask):
         skyCircle = loaderTask.refObjLoader.loadSkyCircle(center, radius,
                                                           loaderTask._referenceFilter,
                                                           epoch=epoch)
-        if not skyCircle.refCat.isContiguous():
-            refCat = skyCircle.refCat.copy(deep=True)
-        else:
-            refCat = skyCircle.refCat
+        refCat = skyCircle.refCat
 
         return refCat, refCatCorrected

--- a/python/lsst/faro/base/CatalogMeasurementBase.py
+++ b/python/lsst/faro/base/CatalogMeasurementBase.py
@@ -1,13 +1,58 @@
+# This file is part of faro.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig
 from lsst.verify.tasks import MetricTask, MetricConfig, MetricConnections
+from lsst.pipe.tasks.loadReferenceCatalog import LoadReferenceCatalogTask
+import lsst.geom
 
 from .BaseSubTasks import NumSourcesTask
 
-__all__ = ('CatalogMeasurementBaseTaskConfig', 'CatalogMeasurementBaseTask')
+__all__ = ('CatalogMeasurementBaseConnections', 'CatalogMeasurementBaseConfig',
+           'CatalogMeasurementBaseTask')
 
 
-class CatalogMeasurementBaseTaskConfig(MetricConfig,
-                                       pipelineConnections=MetricConnections):
+class CatalogMeasurementBaseConnections(MetricConnections,
+                                        defaultTemplates={'refDataset': ''}):
+
+    refCat = pipeBase.connectionTypes.PrerequisiteInput(
+        doc='Reference catalog',
+        name='{refDataset}',
+        storageClass='SimpleCatalog',
+        dimensions=('skypix',),
+        deferLoad=True,
+        multiple=True
+    )
+
+    def __init__(self, *, config=None):
+        super().__init__(config=config)
+        if config.connections.refDataset == '':
+            self.prerequisiteInputs.remove('refCat')
+
+
+class CatalogMeasurementBaseConfig(MetricConfig,
+                                   pipelineConnections=CatalogMeasurementBaseConnections):
+    """Configuration for CatalogMeasurementBaseTask."""
+
     measure = pexConfig.ConfigurableField(
         # This task is meant to make measurements of various types.
         # The default task is, therefore, a bit of a place holder.
@@ -16,15 +61,82 @@ class CatalogMeasurementBaseTaskConfig(MetricConfig,
         target=NumSourcesTask,
         doc="Measure task")
 
+    referenceCatalogLoader = pexConfig.ConfigurableField(
+        target=LoadReferenceCatalogTask,
+        doc="Reference catalog loader",
+    )
+
+    def setDefaults(self):
+        self.referenceCatalogLoader.refObjLoader.ref_dataset_name = ''
+        self.referenceCatalogLoader.doApplyColorTerms = False
+
+    def validate(self):
+        super().validate()
+        if self.connections.refDataset != self.referenceCatalogLoader.refObjLoader.ref_dataset_name:
+            msg = "The reference datasets specified in connections and reference catalog loader must match."
+            raise pexConfig.FieldValidationError(
+                CatalogMeasurementBaseConfig.referenceCatalogLoader, self, msg)
+
 
 class CatalogMeasurementBaseTask(MetricTask):
+    """Base class for science performance metrics measured from source/object catalogs."""
 
-    ConfigClass = CatalogMeasurementBaseTaskConfig
+    ConfigClass = CatalogMeasurementBaseConfig
     _DefaultName = "catalogMeasurementBaseTask"
 
     def __init__(self, config, *args, **kwargs):
         super().__init__(*args, config=config, **kwargs)
         self.makeSubtask('measure')
 
-    def run(self, cat):
-        return self.measure.run(cat, self.config.connections.metric)
+    def run(self, catalog, **kwargs):
+        return self.measure.run(self.config.connections.metric, catalog, **kwargs)
+
+    def getReferenceCatalog(self, butlerQC, inputRefs, refCats, filterList, epoch=None):
+        """Load reference catalog in sky region of interest.
+
+        Parameters
+        ----------
+        butlerQC :
+            Doc
+        inputRefs:
+            Doc
+        refCats:
+            Doc
+        filterList : `list` [`str`]
+            List of camera physicalFilter names to apply color terms.
+
+        Returns
+        -------
+        refCat : `numpy.ndarray`
+            Reference catalog with color terms and proper motions optionally applied.
+        """
+
+        center = lsst.geom.SpherePoint(butlerQC.quantum.dataId.region.getBoundingCircle().getCenter())
+        radius = butlerQC.quantum.dataId.region.getBoundingCircle().getOpeningAngle()
+
+        loaderTask = LoadReferenceCatalogTask(
+            config=self.config.referenceCatalogLoader,
+            dataIds=[ref.datasetRef.dataId
+                     for ref in inputRefs.refCat],
+            refCats=refCats)
+
+        # Get catalog with proper motion and color terms applied
+        # Add this back in after LoadReferenceCatalogTask fix
+        # refCatCorrected = loaderTask.getSkyCircleCatalog(
+        #     center,
+        #     radius,
+        #     filterList,
+        #     epoch=epoch)
+
+        # Get unformatted catalog w/ all columns
+        skyCircle = loaderTask.refObjLoader.loadSkyCircle(center, radius,
+                                                          loaderTask._referenceFilter,
+                                                          epoch=epoch)
+        if not skyCircle.refCat.isContiguous():
+            refCat = skyCircle.refCat.copy(deep=True)
+        else:
+            refCat = skyCircle.refCat
+
+        # Add this back in after LoadReferenceCatalogTask fix
+        # return refCat, refCatCorrected
+        return refCat

--- a/python/lsst/faro/base/CatalogMeasurementBase.py
+++ b/python/lsst/faro/base/CatalogMeasurementBase.py
@@ -121,12 +121,9 @@ class CatalogMeasurementBaseTask(MetricTask):
             refCats=refCats)
 
         # Get catalog with proper motion and color terms applied
-        # Add this back in after LoadReferenceCatalogTask fix
-        # refCatCorrected = loaderTask.getSkyCircleCatalog(
-        #     center,
-        #     radius,
-        #     filterList,
-        #     epoch=epoch)
+        refCatCorrected = loaderTask.getSkyCircleCatalog(center, radius,
+                                                         filterList,
+                                                         epoch=epoch)
 
         # Get unformatted catalog w/ all columns
         skyCircle = loaderTask.refObjLoader.loadSkyCircle(center, radius,
@@ -137,6 +134,4 @@ class CatalogMeasurementBaseTask(MetricTask):
         else:
             refCat = skyCircle.refCat
 
-        # Add this back in after LoadReferenceCatalogTask fix
-        # return refCat, refCatCorrected
-        return refCat
+        return refCat, refCatCorrected

--- a/python/lsst/faro/measurement/DetectorMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorMeasurement.py
@@ -1,8 +1,13 @@
+import os
+
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections
 import lsst.pex.config as pexConfig
+import lsst.geom
+from lsst.utils import getPackageDir
 
 from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
+from lsst.pipe.tasks.loadReferenceCatalog import LoadReferenceCatalogConfig, LoadReferenceCatalogTask
 
 __all__ = ("DetectorMeasurementTaskConfig", "DetectorMeasurementTask",
            "DetectorTableMeasurementTaskConfig", "DetectorTableMeasurementTask")
@@ -139,7 +144,8 @@ class DetectorMeasurementTask(CatalogMeasurementBaseTask):
 
 
 class DetectorTableMeasurementTaskConnections(MetricConnections,
-                                              dimensions=("instrument", "visit", "detector", "band")):
+                                              dimensions=("instrument", "visit", "detector", "band"),
+                                              defaultTemplates={"refDataset": ""}):
 
     catalog = pipeBase.connectionTypes.Input(doc="Source catalog for visit.",
                                              dimensions=("instrument", "visit", "band"),
@@ -147,23 +153,39 @@ class DetectorTableMeasurementTaskConnections(MetricConnections,
                                              name="sourceTable_visit",
                                              deferLoad=True)
 
+    refcat = pipeBase.connectionTypes.PrerequisiteInput(
+        doc="Reference catalog.",
+        name="{refDataset}",
+        storageClass="SimpleCatalog",
+        dimensions=("skypix",),
+        deferLoad=True,
+        multiple=True
+    )
+
     measurement = pipeBase.connectionTypes.Output(doc="Per-detector measurement.",
                                                   dimensions=("instrument", "visit", "detector", "band"),
                                                   storageClass="MetricValue",
                                                   name="metricvalue_{package}_{metric}")
+
+    def __init__(self, *, config=None):
+        super().__init__(config=config)
+        if config.connections.refDataset == '':
+            self.prerequisiteInputs.remove("refcat")
 
 
 class DetectorTableMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
                                          pipelineConnections=DetectorTableMeasurementTaskConnections):
     columns = pexConfig.Field(doc="Columns from sourceTable_visit to load.",
                               dtype=str, default='coord_ra, coord_dec, detector')
+    refDataset = pexConfig.Field(doc="Reference dataset to use.",
+                                 dtype=str, default='')
 
 
 class DetectorTableMeasurementTask(CatalogMeasurementBaseTask):
     ConfigClass = DetectorTableMeasurementTaskConfig
     _DefaultName = "detectorTableMeasurementTask"
 
-    def run(self, catalog, dataIds):
+    def run(self, catalog, dataIds, refcat, refcatCalib):
         return self.measure.run(catalog, self.config.connections.metric, dataIds)
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
@@ -173,6 +195,77 @@ class DetectorTableMeasurementTask(CatalogMeasurementBaseTask):
         selection = (catalog['detector'] == butlerQC.quantum.dataId['detector'])
         inputs['catalog'] = catalog[selection]
         inputs['dataIds'] = [butlerQC.registry.expandDataId(inputRefs.catalog.datasetRef.dataId)]
+
+        if self.config.connections.refDataset != '':
+            config = LoadReferenceCatalogConfig()
+            config.refObjLoader.ref_dataset_name = self.config.connections.refDataset
+
+            # Probably these defaults should be set elsewhere in a common utility
+            if self.config.connections.refDataset == 'gaia_dr2_20200414':
+                # Apply proper motions for Gaia catalog
+                config.refObjLoader.requireProperMotion = True
+                config.refObjLoader.anyFilterMapsToThis = 'phot_g_mean'
+                config.doApplyColorTerms = False
+            elif self.config.connections.refDataset == 'ps1_pv3_3pi_20170110':
+                # Apply color terms for PS1 catalog
+                config.refObjLoader.load(os.path.join(getPackageDir('obs_subaru'),
+                                                      'config',
+                                                      'filterMap.py'))
+                config.colorterms.load(os.path.join(getPackageDir('obs_subaru'),
+                                                    'config',
+                                                    'colorterms.py'))
+
+            # Directly concatenate the reference catalogs
+            # This approach does NOT match rows with LoadReferenceCatalogTask
+            # refCat = inputs['refcat'][0].get()
+            # for handle in inputs['refcat'][1:]:
+            #     refCat.extend(handle.get())
+            # if not refCat.isContiguous():
+            #     refCat = refCat.copy(deep=True)
+            # inputs['refcat'] = refCat
+
+            center = lsst.geom.SpherePoint(butlerQC.quantum.dataId.region.getBoundingCircle().getCenter())
+            radius = butlerQC.quantum.dataId.region.getBoundingCircle().getOpeningAngle()
+
+            epoch = butlerQC.quantum.dataId.records['visit'].timespan.begin
+
+            loaderTask = LoadReferenceCatalogTask(
+                config=config,
+                dataIds=[ref.datasetRef.dataId
+                         for ref in inputRefs.refcat],
+                refCats=inputs.pop('refcat'))
+
+            # Catalog with color terms applied
+            inputs['refcatCalib'] = loaderTask.getSkyCircleCatalog(
+                center,
+                radius,
+                [butlerQC.quantum.dataId.records['physical_filter'].name],
+                epoch=epoch)
+
+            # Next get unformatted catalog
+            skyCircle = loaderTask.refObjLoader.loadSkyCircle(center, radius,
+                                                              loaderTask._referenceFilter,
+                                                              epoch=epoch)
+            if not skyCircle.refCat.isContiguous():
+                inputs['refcat'] = skyCircle.refCat.copy(deep=True)
+            else:
+                inputs['refcat'] = skyCircle.refCat
+
+            # Plotting is only for testing during development
+            # import matplotlib.pyplot as plt
+            # import numpy as np
+            # plt.figure()
+            # plt.scatter(inputs['catalog']['coord_ra'],
+            #             inputs['catalog']['coord_dec'], marker='+')
+            # plt.scatter(np.degrees(refCat['coord_ra']),
+            #             np.degrees(refCat['coord_dec']), marker='x')
+            # plt.scatter(refCatCalib['ra'], refCatCalib['dec'], marker='o')
+            # plt.show()
+            # plt.savefig('test.png')
+            # input('WAIT')
+
+        # import pdb; pdb.set_trace()
+
         outputs = self.run(**inputs)
         if outputs.measurement is not None:
             butlerQC.put(outputs, outputRefs)

--- a/python/lsst/faro/measurement/DetectorMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorMeasurement.py
@@ -1,16 +1,11 @@
-import os
-
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections
 import lsst.pex.config as pexConfig
-import lsst.geom
-from lsst.utils import getPackageDir
 
 from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
-from lsst.pipe.tasks.loadReferenceCatalog import LoadReferenceCatalogConfig, LoadReferenceCatalogTask
 
-__all__ = ("DetectorMeasurementTaskConfig", "DetectorMeasurementTask",
-           "DetectorTableMeasurementTaskConfig", "DetectorTableMeasurementTask")
+
+__all__ = ("DetectorMeasurementTaskConfig", "DetectorMeasurementTask")
 
 
 class DetectorMeasurementTaskConnections(MetricConnections,
@@ -134,137 +129,6 @@ class DetectorMeasurementTask(CatalogMeasurementBaseTask):
             row = externalSkyWcsCatalog.find(detector)
             externalSkyWcs = row.getWcs()
             inputs['skyWcs'] = externalSkyWcs
-
-        outputs = self.run(**inputs)
-        if outputs.measurement is not None:
-            butlerQC.put(outputs, outputRefs)
-        else:
-            self.log.debug("Skipping measurement of {!r} on {} "
-                           "as not applicable.", self, inputRefs)
-
-
-class DetectorTableMeasurementTaskConnections(MetricConnections,
-                                              dimensions=("instrument", "visit", "detector", "band"),
-                                              defaultTemplates={"refDataset": ""}):
-
-    catalog = pipeBase.connectionTypes.Input(doc="Source catalog for visit.",
-                                             dimensions=("instrument", "visit", "band"),
-                                             storageClass="DataFrame",
-                                             name="sourceTable_visit",
-                                             deferLoad=True)
-
-    refcat = pipeBase.connectionTypes.PrerequisiteInput(
-        doc="Reference catalog.",
-        name="{refDataset}",
-        storageClass="SimpleCatalog",
-        dimensions=("skypix",),
-        deferLoad=True,
-        multiple=True
-    )
-
-    measurement = pipeBase.connectionTypes.Output(doc="Per-detector measurement.",
-                                                  dimensions=("instrument", "visit", "detector", "band"),
-                                                  storageClass="MetricValue",
-                                                  name="metricvalue_{package}_{metric}")
-
-    def __init__(self, *, config=None):
-        super().__init__(config=config)
-        if config.connections.refDataset == '':
-            self.prerequisiteInputs.remove("refcat")
-
-
-class DetectorTableMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                         pipelineConnections=DetectorTableMeasurementTaskConnections):
-    columns = pexConfig.Field(doc="Columns from sourceTable_visit to load.",
-                              dtype=str, default='coord_ra, coord_dec, detector')
-    refDataset = pexConfig.Field(doc="Reference dataset to use.",
-                                 dtype=str, default='')
-
-
-class DetectorTableMeasurementTask(CatalogMeasurementBaseTask):
-    ConfigClass = DetectorTableMeasurementTaskConfig
-    _DefaultName = "detectorTableMeasurementTask"
-
-    def run(self, catalog, dataIds, refcat, refcatCalib):
-        return self.measure.run(catalog, self.config.connections.metric, dataIds)
-
-    def runQuantum(self, butlerQC, inputRefs, outputRefs):
-        inputs = butlerQC.get(inputRefs)
-        columns = [_.strip() for _ in self.config.columns.split(',')]
-        catalog = inputs['catalog'].get(parameters={'columns': columns})
-        selection = (catalog['detector'] == butlerQC.quantum.dataId['detector'])
-        inputs['catalog'] = catalog[selection]
-        inputs['dataIds'] = [butlerQC.registry.expandDataId(inputRefs.catalog.datasetRef.dataId)]
-
-        if self.config.connections.refDataset != '':
-            config = LoadReferenceCatalogConfig()
-            config.refObjLoader.ref_dataset_name = self.config.connections.refDataset
-
-            # Probably these defaults should be set elsewhere in a common utility
-            if self.config.connections.refDataset == 'gaia_dr2_20200414':
-                # Apply proper motions for Gaia catalog
-                config.refObjLoader.requireProperMotion = True
-                config.refObjLoader.anyFilterMapsToThis = 'phot_g_mean'
-                config.doApplyColorTerms = False
-            elif self.config.connections.refDataset == 'ps1_pv3_3pi_20170110':
-                # Apply color terms for PS1 catalog
-                config.refObjLoader.load(os.path.join(getPackageDir('obs_subaru'),
-                                                      'config',
-                                                      'filterMap.py'))
-                config.colorterms.load(os.path.join(getPackageDir('obs_subaru'),
-                                                    'config',
-                                                    'colorterms.py'))
-
-            # Directly concatenate the reference catalogs
-            # This approach does NOT match rows with LoadReferenceCatalogTask
-            # refCat = inputs['refcat'][0].get()
-            # for handle in inputs['refcat'][1:]:
-            #     refCat.extend(handle.get())
-            # if not refCat.isContiguous():
-            #     refCat = refCat.copy(deep=True)
-            # inputs['refcat'] = refCat
-
-            center = lsst.geom.SpherePoint(butlerQC.quantum.dataId.region.getBoundingCircle().getCenter())
-            radius = butlerQC.quantum.dataId.region.getBoundingCircle().getOpeningAngle()
-
-            epoch = butlerQC.quantum.dataId.records['visit'].timespan.begin
-
-            loaderTask = LoadReferenceCatalogTask(
-                config=config,
-                dataIds=[ref.datasetRef.dataId
-                         for ref in inputRefs.refcat],
-                refCats=inputs.pop('refcat'))
-
-            # Catalog with color terms applied
-            inputs['refcatCalib'] = loaderTask.getSkyCircleCatalog(
-                center,
-                radius,
-                [butlerQC.quantum.dataId.records['physical_filter'].name],
-                epoch=epoch)
-
-            # Next get unformatted catalog
-            skyCircle = loaderTask.refObjLoader.loadSkyCircle(center, radius,
-                                                              loaderTask._referenceFilter,
-                                                              epoch=epoch)
-            if not skyCircle.refCat.isContiguous():
-                inputs['refcat'] = skyCircle.refCat.copy(deep=True)
-            else:
-                inputs['refcat'] = skyCircle.refCat
-
-            # Plotting is only for testing during development
-            # import matplotlib.pyplot as plt
-            # import numpy as np
-            # plt.figure()
-            # plt.scatter(inputs['catalog']['coord_ra'],
-            #             inputs['catalog']['coord_dec'], marker='+')
-            # plt.scatter(np.degrees(refCat['coord_ra']),
-            #             np.degrees(refCat['coord_dec']), marker='x')
-            # plt.scatter(refCatCalib['ra'], refCatCalib['dec'], marker='o')
-            # plt.show()
-            # plt.savefig('test.png')
-            # input('WAIT')
-
-        # import pdb; pdb.set_trace()
 
         outputs = self.run(**inputs)
         if outputs.measurement is not None:

--- a/python/lsst/faro/measurement/DetectorMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorMeasurement.py
@@ -1,18 +1,36 @@
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections
 import lsst.pex.config as pexConfig
 
-from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
+from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseConfig, CatalogMeasurementBaseTask
 
-__all__ = ("DetectorMeasurementTaskConfig", "DetectorMeasurementTask")
+__all__ = ("DetectorMeasurementConfig", "DetectorMeasurementTask")
 
 
-class DetectorMeasurementTaskConnections(MetricConnections,
-                                         dimensions=("instrument", "visit", "detector", "band"),
-                                         defaultTemplates={"photoCalibName": "calexp.photoCalib",
-                                                           "externalPhotoCalibName": "fgcm",
-                                                           "wcsName": "calexp.wcs",
-                                                           "externalWcsName": "jointcal"}):
+class DetectorMeasurementConnections(MetricConnections,
+                                     dimensions=("instrument", "visit", "detector", "band"),
+                                     defaultTemplates={"photoCalibName": "calexp.photoCalib",
+                                                       "externalPhotoCalibName": "fgcm",
+                                                       "wcsName": "calexp.wcs",
+                                                       "externalWcsName": "jointcal"}):
 
     catalog = pipeBase.connectionTypes.Input(
         doc="Source catalog.",
@@ -89,8 +107,8 @@ class DetectorMeasurementTaskConnections(MetricConnections,
             self.inputs.remove("externalPhotoCalibGlobalCatalog")
 
 
-class DetectorMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                    pipelineConnections=DetectorMeasurementTaskConnections):
+class DetectorMeasurementConfig(CatalogMeasurementBaseConfig,
+                                pipelineConnections=DetectorMeasurementConnections):
     doApplyExternalSkyWcs = pexConfig.Field(doc="Whether or not to use the external wcs.",
                                             dtype=bool, default=False)
     useGlobalExternalSkyWcs = pexConfig.Field(doc="Whether or not to use the global external wcs.",
@@ -102,11 +120,8 @@ class DetectorMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
 
 
 class DetectorMeasurementTask(CatalogMeasurementBaseTask):
-    ConfigClass = DetectorMeasurementTaskConfig
+    ConfigClass = DetectorMeasurementConfig
     _DefaultName = "detectorMeasurementTask"
-
-    def run(self, catalog, photoCalib, skyWcs):
-        return self.measure.run(catalog, self.config.connections.metric)
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         inputs = butlerQC.get(inputRefs)

--- a/python/lsst/faro/measurement/DetectorMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorMeasurement.py
@@ -4,7 +4,6 @@ import lsst.pex.config as pexConfig
 
 from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
 
-
 __all__ = ("DetectorMeasurementTaskConfig", "DetectorMeasurementTask")
 
 

--- a/python/lsst/faro/measurement/DetectorTableMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorTableMeasurement.py
@@ -81,11 +81,12 @@ class DetectorTableMeasurementTask(CatalogMeasurementBaseTask):
             filterList = [butlerQC.quantum.dataId.records['physical_filter'].name]
             # Time at the start of the visit
             epoch = butlerQC.quantum.dataId.records['visit'].timespan.begin
-            refCat, refCatCorrected = self.getReferenceCatalog(butlerQC,
-                                                               inputRefs,
-                                                               refCats,
-                                                               filterList,
-                                                               epoch)
+            refCat, refCatCorrected = self._getReferenceCatalog(butlerQC,
+                                                                [ref.datasetRef.dataId
+                                                                 for ref in inputRefs.refCat],
+                                                                refCats,
+                                                                filterList,
+                                                                epoch)
             kwargs['refCat'] = refCat
             kwargs['refCatCorrected'] = refCatCorrected
 

--- a/python/lsst/faro/measurement/DetectorTableMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorTableMeasurement.py
@@ -1,0 +1,129 @@
+import os
+
+import lsst.pipe.base as pipeBase
+from lsst.verify.tasks import MetricConnections
+import lsst.pex.config as pexConfig
+import lsst.geom
+from lsst.utils import getPackageDir
+
+from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
+from lsst.pipe.tasks.loadReferenceCatalog import LoadReferenceCatalogConfig, LoadReferenceCatalogTask
+
+__all__ = ("DetectorTableMeasurementTaskConfig", "DetectorTableMeasurementTask")
+
+
+class DetectorTableMeasurementTaskConnections(MetricConnections,
+                                              dimensions=("instrument", "visit", "detector", "band"),
+                                              defaultTemplates={"refDataset": ""}):
+
+    catalog = pipeBase.connectionTypes.Input(doc="Source catalog for visit.",
+                                             dimensions=("instrument", "visit", "band"),
+                                             storageClass="DataFrame",
+                                             name="sourceTable_visit",
+                                             deferLoad=True)
+
+    refcat = pipeBase.connectionTypes.PrerequisiteInput(
+        doc="Reference catalog.",
+        name="{refDataset}",
+        storageClass="SimpleCatalog",
+        dimensions=("skypix",),
+        deferLoad=True,
+        multiple=True
+    )
+
+    measurement = pipeBase.connectionTypes.Output(doc="Per-detector measurement.",
+                                                  dimensions=("instrument", "visit", "detector", "band"),
+                                                  storageClass="MetricValue",
+                                                  name="metricvalue_{package}_{metric}")
+
+    def __init__(self, *, config=None):
+        super().__init__(config=config)
+        if config.connections.refDataset == '':
+            self.prerequisiteInputs.remove("refcat")
+
+
+class DetectorTableMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
+                                         pipelineConnections=DetectorTableMeasurementTaskConnections):
+    columns = pexConfig.Field(doc="Columns from sourceTable_visit to load.",
+                              dtype=str, default='coord_ra, coord_dec, detector')
+    refDataset = pexConfig.Field(doc="Reference dataset to use.",
+                                 dtype=str, default='')
+
+
+class DetectorTableMeasurementTask(CatalogMeasurementBaseTask):
+    ConfigClass = DetectorTableMeasurementTaskConfig
+    _DefaultName = "detectorTableMeasurementTask"
+
+    def run(self, catalog, dataIds, refcat, refcatCalib):
+        return self.measure.run(catalog, self.config.connections.metric, dataIds)
+
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        inputs = butlerQC.get(inputRefs)
+        columns = [_.strip() for _ in self.config.columns.split(',')]
+        catalog = inputs['catalog'].get(parameters={'columns': columns})
+        selection = (catalog['detector'] == butlerQC.quantum.dataId['detector'])
+        inputs['catalog'] = catalog[selection]
+        inputs['dataIds'] = [butlerQC.registry.expandDataId(inputRefs.catalog.datasetRef.dataId)]
+
+        if self.config.connections.refDataset != '':
+            config = LoadReferenceCatalogConfig()
+            config.refObjLoader.ref_dataset_name = self.config.connections.refDataset
+
+            # These default configurations for reference catalogs should go
+            # elsewhere in a common utility.
+            if self.config.connections.refDataset == 'gaia_dr2_20200414':
+                # Apply proper motions for Gaia catalog
+                config.refObjLoader.requireProperMotion = True
+                config.refObjLoader.anyFilterMapsToThis = 'phot_g_mean'
+                config.doApplyColorTerms = False
+            elif self.config.connections.refDataset == 'ps1_pv3_3pi_20170110':
+                # Apply color terms for PS1 catalog
+                config.refObjLoader.load(os.path.join(getPackageDir('obs_subaru'),
+                                                      'config',
+                                                      'filterMap.py'))
+                config.colorterms.load(os.path.join(getPackageDir('obs_subaru'),
+                                                    'config',
+                                                    'colorterms.py'))
+
+            # Directly concatenate the reference catalogs
+            # This approach does NOT match rows with LoadReferenceCatalogTask
+            # refCat = inputs['refcat'][0].get()
+            # for handle in inputs['refcat'][1:]:
+            #     refCat.extend(handle.get())
+            # if not refCat.isContiguous():
+            #     refCat = refCat.copy(deep=True)
+            # inputs['refcat'] = refCat
+
+            center = lsst.geom.SpherePoint(butlerQC.quantum.dataId.region.getBoundingCircle().getCenter())
+            radius = butlerQC.quantum.dataId.region.getBoundingCircle().getOpeningAngle()
+
+            epoch = butlerQC.quantum.dataId.records['visit'].timespan.begin
+
+            loaderTask = LoadReferenceCatalogTask(
+                config=config,
+                dataIds=[ref.datasetRef.dataId
+                         for ref in inputRefs.refcat],
+                refCats=inputs.pop('refcat'))
+
+            # Catalog with proper motion and color terms applied
+            inputs['refcatCalib'] = loaderTask.getSkyCircleCatalog(
+                center,
+                radius,
+                [butlerQC.quantum.dataId.records['physical_filter'].name],
+                epoch=epoch)
+
+            # Next get unformatted catalog w/ all columns
+            skyCircle = loaderTask.refObjLoader.loadSkyCircle(center, radius,
+                                                              loaderTask._referenceFilter,
+                                                              epoch=epoch)
+            if not skyCircle.refCat.isContiguous():
+                inputs['refcat'] = skyCircle.refCat.copy(deep=True)
+            else:
+                inputs['refcat'] = skyCircle.refCat
+
+        outputs = self.run(**inputs)
+        if outputs.measurement is not None:
+            butlerQC.put(outputs, outputRefs)
+        else:
+            self.log.debug("Skipping measurement of {!r} on {} "
+                           "as not applicable.", self, inputRefs)

--- a/python/lsst/faro/measurement/DetectorTableMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorTableMeasurement.py
@@ -9,12 +9,12 @@ from lsst.utils import getPackageDir
 from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
 from lsst.pipe.tasks.loadReferenceCatalog import LoadReferenceCatalogConfig, LoadReferenceCatalogTask
 
-__all__ = ("DetectorTableMeasurementTaskConfig", "DetectorTableMeasurementTask")
+__all__ = ("DetectorTableMeasurementConfig", "DetectorTableMeasurementTask")
 
 
-class DetectorTableMeasurementTaskConnections(MetricConnections,
-                                              dimensions=("instrument", "visit", "detector", "band"),
-                                              defaultTemplates={"refDataset": ""}):
+class DetectorTableMeasurementConnections(MetricConnections,
+                                          dimensions=("instrument", "visit", "detector", "band"),
+                                          defaultTemplates={"refDataset": ""}):
 
     catalog = pipeBase.connectionTypes.Input(doc="Source catalog for visit.",
                                              dimensions=("instrument", "visit", "band"),
@@ -42,8 +42,8 @@ class DetectorTableMeasurementTaskConnections(MetricConnections,
             self.prerequisiteInputs.remove("refcat")
 
 
-class DetectorTableMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                         pipelineConnections=DetectorTableMeasurementTaskConnections):
+class DetectorTableMeasurementConfig(CatalogMeasurementBaseTaskConfig,
+                                     pipelineConnections=DetectorTableMeasurementConnections):
     columns = pexConfig.Field(doc="Columns from sourceTable_visit to load.",
                               dtype=str, default='coord_ra, coord_dec, detector')
     refDataset = pexConfig.Field(doc="Reference dataset to use.",
@@ -51,7 +51,7 @@ class DetectorTableMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
 
 
 class DetectorTableMeasurementTask(CatalogMeasurementBaseTask):
-    ConfigClass = DetectorTableMeasurementTaskConfig
+    ConfigClass = DetectorTableMeasurementConfig
     _DefaultName = "detectorTableMeasurementTask"
 
     def run(self, catalog, dataIds, refcat, refcatCalib):

--- a/python/lsst/faro/measurement/DetectorTableMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorTableMeasurement.py
@@ -1,3 +1,24 @@
+# This file is part of faro.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import os
 
 import lsst.pipe.base as pipeBase

--- a/python/lsst/faro/measurement/DetectorTableMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorTableMeasurement.py
@@ -32,7 +32,7 @@ __all__ = ("DetectorTableMeasurementConfig", "DetectorTableMeasurementTask")
 
 class DetectorTableMeasurementConnections(MetricConnections,
                                           dimensions=("instrument", "visit", "detector", "band"),
-                                          defaultTemplates={"refDataset": ""}):
+                                          defaultTemplates={"refDataset": "gaia_dr2_20200414"}):
 
     catalog = pipeBase.connectionTypes.Input(
         doc="Source table in parquet format, per visit",
@@ -86,6 +86,9 @@ class DetectorTableMeasurementConfig(CatalogMeasurementBaseTaskConfig,
         super().validate()
         if 'detector' not in self.columns:
             msg = "The column `detector` must be appear in the list of columns."
+            raise pexConfig.FieldValidationError(DetectorTableMeasurementConfig.columns, self, msg)
+        if self.connections.refDataset != self.refObjLoader.refObjLoader.ref_dataset_name:
+            msg = "The reference datasets specified in connections and reference object loader must match."
             raise pexConfig.FieldValidationError(DetectorTableMeasurementConfig.columns, self, msg)
 
 

--- a/python/lsst/faro/measurement/DetectorTableMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorTableMeasurement.py
@@ -20,10 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import lsst.pipe.base as pipeBase
-# from lsst.verify.tasks import MetricConnections
 import lsst.pex.config as pexConfig
-# import lsst.geom
-# from lsst.pipe.tasks.loadReferenceCatalog import LoadReferenceCatalogTask
 
 from lsst.faro.base.CatalogMeasurementBase import (CatalogMeasurementBaseConnections,
                                                    CatalogMeasurementBaseConfig,
@@ -34,7 +31,6 @@ __all__ = ("DetectorTableMeasurementConfig", "DetectorTableMeasurementTask")
 
 class DetectorTableMeasurementConnections(CatalogMeasurementBaseConnections,
                                           dimensions=("instrument", "visit", "detector", "band"),
-                                          # defaultTemplates={"refDataset": "gaia_dr2_20200414"}):
                                           defaultTemplates={"refDataset": ""}):
 
     catalog = pipeBase.connectionTypes.Input(
@@ -45,26 +41,12 @@ class DetectorTableMeasurementConnections(CatalogMeasurementBaseConnections,
         deferLoad=True
     )
 
-    # refcat = pipeBase.connectionTypes.PrerequisiteInput(
-    #     doc="Reference catalog",
-    #     name="{refDataset}",
-    #     storageClass="SimpleCatalog",
-    #     dimensions=("skypix",),
-    #     deferLoad=True,
-    #     multiple=True
-    # )
-
     measurement = pipeBase.connectionTypes.Output(
         doc="Per-detector measurement",
         dimensions=("instrument", "visit", "detector", "band"),
         storageClass="MetricValue",
         name="metricvalue_{package}_{metric}"
     )
-
-    # def __init__(self, *, config=None):
-    #     super().__init__(config=config)
-    #     if config.connections.refDataset == '':
-    #         self.prerequisiteInputs.remove("refcat")
 
 
 class DetectorTableMeasurementConfig(CatalogMeasurementBaseConfig,
@@ -74,26 +56,11 @@ class DetectorTableMeasurementConfig(CatalogMeasurementBaseConfig,
     columns = pexConfig.ListField(doc="Columns from sourceTable_visit to load.",
                                   dtype=str, default=['coord_ra', 'coord_dec', 'detector'])
 
-    # referenceCatalogLoader = pexConfig.ConfigurableField(
-    #     target=LoadReferenceCatalogTask,
-    #     doc="Reference object loader",
-    # )
-
-    # def setDefaults(self):
-    #     self.referenceCatalogLoader.refObjLoader.ref_dataset_name = "gaia_dr2_20200414"
-    #     self.referenceCatalogLoader.refObjLoader.requireProperMotion = True
-    #     self.referenceCatalogLoader.refObjLoader.anyFilterMapsToThis = 'phot_g_mean'
-    #     self.referenceCatalogLoader.doApplyColorTerms = False
-
     def validate(self):
         super().validate()
         if 'detector' not in self.columns:
             msg = "The column `detector` must be appear in the list of columns."
             raise pexConfig.FieldValidationError(DetectorTableMeasurementConfig.columns, self, msg)
-        # if self.connections.refDataset != self.referenceCatalogLoader.refObjLoader.ref_dataset_name:
-        #      msg = "Reference datasets specified in connections and reference catalog loader must match."
-        #      raise pexConfig.FieldValidationError(
-        #          DetectorTableMeasurementConfig.referenceCatalogLoader, self, msg)
 
 
 class DetectorTableMeasurementTask(CatalogMeasurementBaseTask):
@@ -101,10 +68,6 @@ class DetectorTableMeasurementTask(CatalogMeasurementBaseTask):
 
     ConfigClass = DetectorTableMeasurementConfig
     _DefaultName = "detectorTableMeasurementTask"
-
-    # def run(self, catalog, refcat, refcatCorrected):
-    #     return self.measure.run(self.config.connections.metric, catalog,
-    #                             refCat=refCat, refCatCorrected=refCatCorrected)
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         inputs = butlerQC.get(inputRefs)
@@ -118,52 +81,14 @@ class DetectorTableMeasurementTask(CatalogMeasurementBaseTask):
             filterList = [butlerQC.quantum.dataId.records['physical_filter'].name]
             # Time at the start of the visit
             epoch = butlerQC.quantum.dataId.records['visit'].timespan.begin
-            # Add this back in after LoadReferenceCatalogTask fix
-            # refCat, refCatCorrected = self.getReferenceCatalog(butlerQC,
-            #                                                    inputRefs,
-            #                                                    refCats,
-            #                                                    filterList,
-            #                                                    epoch)
-            refCat = self.getReferenceCatalog(butlerQC,
-                                              inputRefs,
-                                              refCats,
-                                              filterList,
-                                              epoch)
+            refCat, refCatCorrected = self.getReferenceCatalog(butlerQC,
+                                                               inputRefs,
+                                                               refCats,
+                                                               filterList,
+                                                               epoch)
             kwargs['refCat'] = refCat
-            # Add this back in after LoadReferenceCatalogTask fix
-            # kwargs['refCatCorrected'] = refCatCorrected
+            kwargs['refCatCorrected'] = refCatCorrected
 
-            """
-            center = lsst.geom.SpherePoint(butlerQC.quantum.dataId.region.getBoundingCircle().getCenter())
-            radius = butlerQC.quantum.dataId.region.getBoundingCircle().getOpeningAngle()
-
-            epoch = butlerQC.quantum.dataId.records['visit'].timespan.begin
-
-            loaderTask = LoadReferenceCatalogTask(
-                config=self.config.refObjLoader,
-                dataIds=[ref.datasetRef.dataId
-                         for ref in inputRefs.refcat],
-                refCats=inputs.pop('refcat'))
-
-            # Catalog with proper motion and color terms applied
-            refcatCalib = loaderTask.getSkyCircleCatalog(
-                center,
-                radius,
-                [butlerQC.quantum.dataId.records['physical_filter'].name],
-                epoch=epoch)
-
-            # Next get unformatted catalog w/ all columns
-            skyCircle = loaderTask.refObjLoader.loadSkyCircle(center, radius,
-                                                              loaderTask._referenceFilter,
-                                                              epoch=epoch)
-            if not skyCircle.refCat.isContiguous():
-                refcat = skyCircle.refCat.copy(deep=True)
-            else:
-                refcat = skyCircle.refCat
-            """
-
-        # Add this back in after LoadReferenceCatalogTask fix
-        # outputs = self.run(catalog, refcat, refcatCalib)
         outputs = self.run(catalog, **kwargs)
         if outputs.measurement is not None:
             butlerQC.put(outputs, outputRefs)

--- a/python/lsst/faro/measurement/DetectorTableMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorTableMeasurement.py
@@ -92,7 +92,7 @@ class DetectorTableMeasurementTask(CatalogMeasurementBaseTask):
         inputs = butlerQC.get(inputRefs)
         catalog = inputs['catalog'].get(parameters={'columns': self.config.columns})
         selection = (catalog['detector'] == butlerQC.quantum.dataId['detector'])
-        inputs['catalog'] = catalog[selection]
+        catalog = catalog[selection]
 
         if self.config.connections.refDataset != '':
             config = LoadReferenceCatalogConfig()

--- a/python/lsst/faro/measurement/MatchedCatalogMeasurement.py
+++ b/python/lsst/faro/measurement/MatchedCatalogMeasurement.py
@@ -1,24 +1,42 @@
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import traceback
 
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections, MetricComputationError
 
-from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
+from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseConfig, CatalogMeasurementBaseTask
 
-__all__ = ("PatchMatchedMeasurementTaskConnections", "PatchMatchedMeasurementTaskConfig",
+__all__ = ("PatchMatchedMeasurementConnections", "PatchMatchedMeasurementConfig",
            "PatchMatchedMeasurementTask",
-           "TractMatchedMeasurementTaskConnections", "TractMatchedMeasurementTaskConfig",
+           "TractMatchedMeasurementConnections", "TractMatchedMeasurementConfig",
            "TractMatchedMeasurementTask",
-           "PatchMatchedMultiBandMeasurementTaskConnections", "PatchMatchedMultiBandMeasurementTaskConfig",
+           "PatchMatchedMultiBandMeasurementConnections", "PatchMatchedMultiBandMeasurementConfig",
            "PatchMatchedMultiBandMeasurementTask")
 
 # The first thing to do is to define a Connections class. This will define all
 # the inputs and outputs that our task requires
 
 
-class PatchMatchedMeasurementTaskConnections(MetricConnections,
-                                             dimensions=("tract", "patch", "band",
-                                                         "instrument", "skymap")):
+class PatchMatchedMeasurementConnections(MetricConnections,
+                                         dimensions=("tract", "patch", "band",
+                                                     "instrument", "skymap")):
     cat = pipeBase.connectionTypes.Input(doc="Input matched catalog.",
                                          dimensions=("tract", "patch", "instrument",
                                                      "band"),
@@ -31,19 +49,19 @@ class PatchMatchedMeasurementTaskConnections(MetricConnections,
                                                   name="metricvalue_{package}_{metric}")
 
 
-class PatchMatchedMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                        pipelineConnections=PatchMatchedMeasurementTaskConnections):
+class PatchMatchedMeasurementConfig(CatalogMeasurementBaseConfig,
+                                    pipelineConnections=PatchMatchedMeasurementConnections):
     pass
 
 
 class PatchMatchedMeasurementTask(CatalogMeasurementBaseTask):
-    ConfigClass = PatchMatchedMeasurementTaskConfig
+    ConfigClass = PatchMatchedMeasurementConfig
     _DefaultName = "patchMatchedMeasurementTask"
 
 
-class TractMatchedMeasurementTaskConnections(PatchMatchedMeasurementTaskConnections,
-                                             dimensions=("tract", "instrument",
-                                                         "band", "skymap")):
+class TractMatchedMeasurementConnections(PatchMatchedMeasurementConnections,
+                                         dimensions=("tract", "instrument",
+                                                     "band", "skymap")):
     cat = pipeBase.connectionTypes.Input(doc="Input matched catalog.",
                                          dimensions=("tract", "instrument",
                                                      "band"),
@@ -56,19 +74,19 @@ class TractMatchedMeasurementTaskConnections(PatchMatchedMeasurementTaskConnecti
                                                   name="metricvalue_{package}_{metric}")
 
 
-class TractMatchedMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                        pipelineConnections=TractMatchedMeasurementTaskConnections):
+class TractMatchedMeasurementConfig(CatalogMeasurementBaseConfig,
+                                    pipelineConnections=TractMatchedMeasurementConnections):
     pass
 
 
 class TractMatchedMeasurementTask(CatalogMeasurementBaseTask):
-    ConfigClass = TractMatchedMeasurementTaskConfig
+    ConfigClass = TractMatchedMeasurementConfig
     _DefaultName = "tractMatchedMeasurementTask"
 
 
-class PatchMatchedMultiBandMeasurementTaskConnections(MetricConnections,
-                                                      dimensions=("tract", "patch", "band",
-                                                                  "instrument", "skymap")):
+class PatchMatchedMultiBandMeasurementConnections(MetricConnections,
+                                                  dimensions=("tract", "patch", "band",
+                                                              "instrument", "skymap")):
     cat = pipeBase.connectionTypes.Input(doc="Input matched catalog.",
                                          dimensions=("tract", "patch", "instrument"),
                                          storageClass="SimpleCatalog",
@@ -80,14 +98,14 @@ class PatchMatchedMultiBandMeasurementTaskConnections(MetricConnections,
                                                   name="metricvalue_{package}_{metric}")
 
 
-class PatchMatchedMultiBandMeasurementTaskConfig(
-        CatalogMeasurementBaseTaskConfig,
-        pipelineConnections=PatchMatchedMultiBandMeasurementTaskConnections):
+class PatchMatchedMultiBandMeasurementConfig(
+        CatalogMeasurementBaseConfig,
+        pipelineConnections=PatchMatchedMultiBandMeasurementConnections):
     pass
 
 
 class PatchMatchedMultiBandMeasurementTask(CatalogMeasurementBaseTask):
-    ConfigClass = PatchMatchedMultiBandMeasurementTaskConfig
+    ConfigClass = PatchMatchedMultiBandMeasurementConfig
     _DefaultName = "patchMatchedMultiBandMeasurementTask"
 
     def run(self, cat, in_id, out_id):

--- a/python/lsst/faro/measurement/PatchMeasurement.py
+++ b/python/lsst/faro/measurement/PatchMeasurement.py
@@ -1,15 +1,33 @@
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections
 
-from lsst.faro.base.CatalogMeasurementBase import (CatalogMeasurementBaseTaskConfig,
+from lsst.faro.base.CatalogMeasurementBase import (CatalogMeasurementBaseConfig,
                                                    CatalogMeasurementBaseTask)
 
-__all__ = ("PatchMeasurementTaskConnections", "PatchMeasurementTaskConfig", "PatchMeasurementTask")
+__all__ = ("PatchMeasurementConnections", "PatchMeasurementConfig", "PatchMeasurementTask")
 
 
-class PatchMeasurementTaskConnections(MetricConnections,
-                                      dimensions=("tract", "patch", "skymap",
-                                                  "band")):
+class PatchMeasurementConnections(MetricConnections,
+                                  dimensions=("tract", "patch", "skymap",
+                                              "band")):
 
     cat = pipeBase.connectionTypes.Input(doc="Object catalog.",
                                          dimensions=("tract", "patch", "skymap",
@@ -24,14 +42,14 @@ class PatchMeasurementTaskConnections(MetricConnections,
                                                   name="metricvalue_{package}_{metric}")
 
 
-class PatchMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                 pipelineConnections=PatchMeasurementTaskConnections):
+class PatchMeasurementConfig(CatalogMeasurementBaseConfig,
+                             pipelineConnections=PatchMeasurementConnections):
     pass
 
 
 class PatchMeasurementTask(CatalogMeasurementBaseTask):
 
-    ConfigClass = PatchMeasurementTaskConfig
+    ConfigClass = PatchMeasurementConfig
     _DefaultName = "patchMeasurementTask"
 
     def run(self, cat, vIds):

--- a/python/lsst/faro/measurement/TractMeasurement.py
+++ b/python/lsst/faro/measurement/TractMeasurement.py
@@ -1,20 +1,38 @@
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections
 
-from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
+from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseConfig, CatalogMeasurementBaseTask
 
-__all__ = ("TractMeasurementTaskConnections", "TractMeasurementTaskConfig",
+__all__ = ("TractMeasurementConnections", "TractMeasurementConfig",
            "TractMeasurementTask",
-           "TractMultiBandMeasurementTaskConnections", "TractMultiBandMeasurementTaskConfig",
+           "TractMultiBandMeasurementConnections", "TractMultiBandMeasurementConfig",
            "TractMultiBandMeasurementTask")
 
 
-class TractMeasurementTaskConnections(MetricConnections,
-                                      dimensions=("tract", "skymap",
-                                                  "band"),
-                                      defaultTemplates={"coaddName": "deepCoadd",
-                                                        "photoCalibName": "deepCoadd_calexp.photoCalib",
-                                                        "wcsName": "deepCoadd_calexp.wcs"}):
+class TractMeasurementConnections(MetricConnections,
+                                  dimensions=("tract", "skymap",
+                                              "band"),
+                                  defaultTemplates={"coaddName": "deepCoadd",
+                                                    "photoCalibName": "deepCoadd_calexp.photoCalib",
+                                                    "wcsName": "deepCoadd_calexp.wcs"}):
 
     catalogs = pipeBase.connectionTypes.Input(doc="Object catalog.",
                                               dimensions=("tract", "patch",
@@ -44,14 +62,14 @@ class TractMeasurementTaskConnections(MetricConnections,
                                                   name="metricvalue_{package}_{metric}")
 
 
-class TractMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                 pipelineConnections=TractMeasurementTaskConnections):
+class TractMeasurementConfig(CatalogMeasurementBaseConfig,
+                             pipelineConnections=TractMeasurementConnections):
     pass
 
 
 class TractMeasurementTask(CatalogMeasurementBaseTask):
 
-    ConfigClass = TractMeasurementTaskConfig
+    ConfigClass = TractMeasurementConfig
     _DefaultName = "tractMeasurementTask"
 
     def run(self, catalogs, photoCalibs, astromCalibs, dataIds):
@@ -68,10 +86,10 @@ class TractMeasurementTask(CatalogMeasurementBaseTask):
                            "as not applicable.", self, inputRefs)
 
 
-class TractMultiBandMeasurementTaskConnections(TractMeasurementTaskConnections,
-                                               dimensions=("tract", "skymap"),
-                                               defaultTemplates={"coaddName": "deepCoadd", "photoCalibName":
-                                                                 "deepCoadd_calexp.photoCalib"}):
+class TractMultiBandMeasurementConnections(TractMeasurementConnections,
+                                           dimensions=("tract", "skymap"),
+                                           defaultTemplates={"coaddName": "deepCoadd", "photoCalibName":
+                                                             "deepCoadd_calexp.photoCalib"}):
 
     cat = pipeBase.connectionTypes.Input(doc="Object catalog.",
                                          dimensions=("tract", "skymap", "patch",
@@ -93,12 +111,12 @@ class TractMultiBandMeasurementTaskConnections(TractMeasurementTaskConnections,
                                                   name="metricvalue_{package}_{metric}")
 
 
-class TractMultiBandMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                          pipelineConnections=TractMultiBandMeasurementTaskConnections):
+class TractMultiBandMeasurementConfig(CatalogMeasurementBaseConfig,
+                                      pipelineConnections=TractMultiBandMeasurementConnections):
     pass
 
 
 class TractMultiBandMeasurementTask(TractMeasurementTask):
 
-    ConfigClass = TractMultiBandMeasurementTaskConfig
+    ConfigClass = TractMultiBandMeasurementConfig
     _DefaultName = "tractMultiBandMeasurementTask"

--- a/python/lsst/faro/measurement/VisitMeasurement.py
+++ b/python/lsst/faro/measurement/VisitMeasurement.py
@@ -1,9 +1,11 @@
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections
+import lsst.pex.config as pexConfig
 
 from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
 
-__all__ = ("VisitMeasurementTaskConfig", "VisitMeasurementTask")
+__all__ = ("VisitMeasurementTaskConfig", "VisitMeasurementTask",
+           "VisitTableMeasurementTaskConfig", "VisitTableMeasurementTask")
 
 
 class VisitMeasurementTaskConnections(MetricConnections,
@@ -59,3 +61,44 @@ class VisitMeasurementTask(CatalogMeasurementBaseTask):
         else:
             self.log.debug("Skipping measurement of {!r} on {} "
                            "as not applicable.", self, inputRefs)
+
+
+class VisitTableMeasurementTaskConnections(MetricConnections,
+                                           dimensions=("instrument", "visit", "band")):
+
+    catalog = pipeBase.connectionTypes.Input(doc="Source catalog for visit.",
+                                             dimensions=("instrument", "visit", "band"),
+                                             storageClass="DataFrame",
+                                             name="sourceTable_visit",
+                                             deferLoad=True)
+
+    measurement = pipeBase.connectionTypes.Output(doc="Per-visit measurement.",
+                                                  dimensions=("instrument", "visit", "band"),
+                                                  storageClass="MetricValue",
+                                                  name="metricvalue_{package}_{metric}")
+
+
+class VisitTableMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
+                                      pipelineConnections=VisitTableMeasurementTaskConnections):
+    columns = pexConfig.Field(doc="Columns from sourceTable_visit to load.",
+                              dtype=str, default='coord_ra, coord_dec')
+
+
+class VisitTableMeasurementTask(CatalogMeasurementBaseTask):
+    ConfigClass = VisitTableMeasurementTaskConfig
+    _DefaultName = "visitTableMeasurementTask"
+
+    def run(self, catalog, dataIds):
+        return self.measure.run(catalog, self.config.connections.metric, dataIds)
+
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        inputs = butlerQC.get(inputRefs)
+        columns = [_.strip() for _ in self.config.columns.split(',')]
+        inputs['catalog'] = inputs['catalog'].get(parameters={'columns': columns})
+        inputs['dataIds'] = [butlerQC.registry.expandDataId(inputRefs.catalog.datasetRef.dataId)]
+        outputs = self.run(**inputs)
+        if outputs.measurement is not None:
+            butlerQC.put(outputs, outputRefs)
+        else:
+            self.log.debugf("Skipping measurement of {!r} on {} "
+                            "as not applicable.", self, inputRefs)

--- a/python/lsst/faro/measurement/VisitMeasurement.py
+++ b/python/lsst/faro/measurement/VisitMeasurement.py
@@ -1,11 +1,9 @@
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections
-import lsst.pex.config as pexConfig
 
 from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
 
-__all__ = ("VisitMeasurementTaskConfig", "VisitMeasurementTask",
-           "VisitTableMeasurementTaskConfig", "VisitTableMeasurementTask")
+__all__ = ("VisitMeasurementTaskConfig", "VisitMeasurementTask")
 
 
 class VisitMeasurementTaskConnections(MetricConnections,
@@ -61,44 +59,3 @@ class VisitMeasurementTask(CatalogMeasurementBaseTask):
         else:
             self.log.debug("Skipping measurement of {!r} on {} "
                            "as not applicable.", self, inputRefs)
-
-
-class VisitTableMeasurementTaskConnections(MetricConnections,
-                                           dimensions=("instrument", "visit", "band")):
-
-    catalog = pipeBase.connectionTypes.Input(doc="Source catalog for visit.",
-                                             dimensions=("instrument", "visit", "band"),
-                                             storageClass="DataFrame",
-                                             name="sourceTable_visit",
-                                             deferLoad=True)
-
-    measurement = pipeBase.connectionTypes.Output(doc="Per-visit measurement.",
-                                                  dimensions=("instrument", "visit", "band"),
-                                                  storageClass="MetricValue",
-                                                  name="metricvalue_{package}_{metric}")
-
-
-class VisitTableMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                      pipelineConnections=VisitTableMeasurementTaskConnections):
-    columns = pexConfig.Field(doc="Columns from sourceTable_visit to load.",
-                              dtype=str, default='coord_ra, coord_dec')
-
-
-class VisitTableMeasurementTask(CatalogMeasurementBaseTask):
-    ConfigClass = VisitTableMeasurementTaskConfig
-    _DefaultName = "visitTableMeasurementTask"
-
-    def run(self, catalog, dataIds):
-        return self.measure.run(catalog, self.config.connections.metric, dataIds)
-
-    def runQuantum(self, butlerQC, inputRefs, outputRefs):
-        inputs = butlerQC.get(inputRefs)
-        columns = [_.strip() for _ in self.config.columns.split(',')]
-        inputs['catalog'] = inputs['catalog'].get(parameters={'columns': columns})
-        inputs['dataIds'] = [butlerQC.registry.expandDataId(inputRefs.catalog.datasetRef.dataId)]
-        outputs = self.run(**inputs)
-        if outputs.measurement is not None:
-            butlerQC.put(outputs, outputRefs)
-        else:
-            self.log.debugf("Skipping measurement of {!r} on {} "
-                            "as not applicable.", self, inputRefs)

--- a/python/lsst/faro/measurement/VisitMeasurement.py
+++ b/python/lsst/faro/measurement/VisitMeasurement.py
@@ -1,15 +1,33 @@
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections
 
-from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
+from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseConfig, CatalogMeasurementBaseTask
 
-__all__ = ("VisitMeasurementTaskConfig", "VisitMeasurementTask")
+__all__ = ("VisitMeasurementConfig", "VisitMeasurementTask")
 
 
-class VisitMeasurementTaskConnections(MetricConnections,
-                                      dimensions=("instrument", "visit", "band"),
-                                      defaultTemplates={"photoCalibName": "calexp.photoCalib",
-                                                        "wcsName": "calexp.wcs"}):
+class VisitMeasurementConnections(MetricConnections,
+                                  dimensions=("instrument", "visit", "band"),
+                                  defaultTemplates={"photoCalibName": "calexp.photoCalib",
+                                                    "wcsName": "calexp.wcs"}):
 
     catalogs = pipeBase.connectionTypes.Input(doc="Source catalogs.",
                                               dimensions=("instrument", "visit",
@@ -38,17 +56,14 @@ class VisitMeasurementTaskConnections(MetricConnections,
                                                   name="metricvalue_{package}_{metric}")
 
 
-class VisitMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                 pipelineConnections=VisitMeasurementTaskConnections):
+class VisitMeasurementConfig(CatalogMeasurementBaseConfig,
+                             pipelineConnections=VisitMeasurementConnections):
     pass
 
 
 class VisitMeasurementTask(CatalogMeasurementBaseTask):
-    ConfigClass = VisitMeasurementTaskConfig
+    ConfigClass = VisitMeasurementConfig
     _DefaultName = "visitMeasurementTask"
-
-    def run(self, catalogs, photoCalibs, astromCalibs, dataIds):
-        return self.measure.run(self.config.connections.metric, catalogs, photoCalibs, astromCalibs, dataIds)
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         inputs = butlerQC.get(inputRefs)

--- a/python/lsst/faro/measurement/VisitTableMeasurement.py
+++ b/python/lsst/faro/measurement/VisitTableMeasurement.py
@@ -49,6 +49,8 @@ class VisitTableMeasurementConnections(MetricConnections,
 
 class VisitTableMeasurementConfig(CatalogMeasurementBaseTaskConfig,
                                   pipelineConnections=VisitTableMeasurementConnections):
+    """Configuration for VisitTableMeasurementTask."""
+
     columns = pexConfig.ListField(doc="Columns from sourceTable_visit to load.",
                                   dtype=str, default=['coord_ra', 'coord_dec'])
 

--- a/python/lsst/faro/measurement/VisitTableMeasurement.py
+++ b/python/lsst/faro/measurement/VisitTableMeasurement.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import lsst.pipe.base as pipeBase
-# from lsst.verify.tasks import MetricConnections
 import lsst.pex.config as pexConfig
 
 from lsst.faro.base.CatalogMeasurementBase import (CatalogMeasurementBaseConnections,

--- a/python/lsst/faro/measurement/VisitTableMeasurement.py
+++ b/python/lsst/faro/measurement/VisitTableMeasurement.py
@@ -20,19 +20,21 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import lsst.pipe.base as pipeBase
-from lsst.verify.tasks import MetricConnections
+# from lsst.verify.tasks import MetricConnections
 import lsst.pex.config as pexConfig
 
-from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
+from lsst.faro.base.CatalogMeasurementBase import (CatalogMeasurementBaseConnections,
+                                                   CatalogMeasurementBaseConfig,
+                                                   CatalogMeasurementBaseTask)
 
 __all__ = ("VisitTableMeasurementConfig", "VisitTableMeasurementTask")
 
 
-class VisitTableMeasurementConnections(MetricConnections,
+class VisitTableMeasurementConnections(CatalogMeasurementBaseConnections,
                                        dimensions=("instrument", "visit", "band")):
 
     catalog = pipeBase.connectionTypes.Input(
-        doc="Source catalog for visit.",
+        doc="Source table in parquet format, per visit",
         dimensions=("instrument", "visit", "band"),
         storageClass="DataFrame",
         name="sourceTable_visit",
@@ -40,14 +42,14 @@ class VisitTableMeasurementConnections(MetricConnections,
     )
 
     measurement = pipeBase.connectionTypes.Output(
-        doc="Per-visit measurement.",
+        doc="Per-visit measurement",
         dimensions=("instrument", "visit", "band"),
         storageClass="MetricValue",
         name="metricvalue_{package}_{metric}"
     )
 
 
-class VisitTableMeasurementConfig(CatalogMeasurementBaseTaskConfig,
+class VisitTableMeasurementConfig(CatalogMeasurementBaseConfig,
                                   pipelineConnections=VisitTableMeasurementConnections):
     """Configuration for VisitTableMeasurementTask."""
 

--- a/python/lsst/faro/measurement/VisitTableMeasurement.py
+++ b/python/lsst/faro/measurement/VisitTableMeasurement.py
@@ -1,0 +1,48 @@
+import lsst.pipe.base as pipeBase
+from lsst.verify.tasks import MetricConnections
+import lsst.pex.config as pexConfig
+
+from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
+
+__all__ = ("VisitTableMeasurementTaskConfig", "VisitTableMeasurementTask")
+
+
+class VisitTableMeasurementTaskConnections(MetricConnections,
+                                           dimensions=("instrument", "visit", "band")):
+
+    catalog = pipeBase.connectionTypes.Input(doc="Source catalog for visit.",
+                                             dimensions=("instrument", "visit", "band"),
+                                             storageClass="DataFrame",
+                                             name="sourceTable_visit",
+                                             deferLoad=True)
+
+    measurement = pipeBase.connectionTypes.Output(doc="Per-visit measurement.",
+                                                  dimensions=("instrument", "visit", "band"),
+                                                  storageClass="MetricValue",
+                                                  name="metricvalue_{package}_{metric}")
+
+
+class VisitTableMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
+                                      pipelineConnections=VisitTableMeasurementTaskConnections):
+    columns = pexConfig.Field(doc="Columns from sourceTable_visit to load.",
+                              dtype=str, default='coord_ra, coord_dec')
+
+
+class VisitTableMeasurementTask(CatalogMeasurementBaseTask):
+    ConfigClass = VisitTableMeasurementTaskConfig
+    _DefaultName = "visitTableMeasurementTask"
+
+    def run(self, catalog, dataIds):
+        return self.measure.run(catalog, self.config.connections.metric, dataIds)
+
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        inputs = butlerQC.get(inputRefs)
+        columns = [_.strip() for _ in self.config.columns.split(',')]
+        inputs['catalog'] = inputs['catalog'].get(parameters={'columns': columns})
+        inputs['dataIds'] = [butlerQC.registry.expandDataId(inputRefs.catalog.datasetRef.dataId)]
+        outputs = self.run(**inputs)
+        if outputs.measurement is not None:
+            butlerQC.put(outputs, outputRefs)
+        else:
+            self.log.debugf("Skipping measurement of {!r} on {} "
+                            "as not applicable.", self, inputRefs)

--- a/python/lsst/faro/measurement/VisitTableMeasurement.py
+++ b/python/lsst/faro/measurement/VisitTableMeasurement.py
@@ -1,3 +1,24 @@
+# This file is part of faro.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import lsst.pipe.base as pipeBase
 from lsst.verify.tasks import MetricConnections
 import lsst.pex.config as pexConfig

--- a/python/lsst/faro/measurement/VisitTableMeasurement.py
+++ b/python/lsst/faro/measurement/VisitTableMeasurement.py
@@ -31,16 +31,20 @@ __all__ = ("VisitTableMeasurementConfig", "VisitTableMeasurementTask")
 class VisitTableMeasurementConnections(MetricConnections,
                                        dimensions=("instrument", "visit", "band")):
 
-    catalog = pipeBase.connectionTypes.Input(doc="Source catalog for visit.",
-                                             dimensions=("instrument", "visit", "band"),
-                                             storageClass="DataFrame",
-                                             name="sourceTable_visit",
-                                             deferLoad=True)
+    catalog = pipeBase.connectionTypes.Input(
+        doc="Source catalog for visit.",
+        dimensions=("instrument", "visit", "band"),
+        storageClass="DataFrame",
+        name="sourceTable_visit",
+        deferLoad=True
+    )
 
-    measurement = pipeBase.connectionTypes.Output(doc="Per-visit measurement.",
-                                                  dimensions=("instrument", "visit", "band"),
-                                                  storageClass="MetricValue",
-                                                  name="metricvalue_{package}_{metric}")
+    measurement = pipeBase.connectionTypes.Output(
+        doc="Per-visit measurement.",
+        dimensions=("instrument", "visit", "band"),
+        storageClass="MetricValue",
+        name="metricvalue_{package}_{metric}"
+    )
 
 
 class VisitTableMeasurementConfig(CatalogMeasurementBaseTaskConfig,
@@ -50,17 +54,17 @@ class VisitTableMeasurementConfig(CatalogMeasurementBaseTaskConfig,
 
 
 class VisitTableMeasurementTask(CatalogMeasurementBaseTask):
+    """Base class for science performance metrics measured on single-visit source catalogs."""
     ConfigClass = VisitTableMeasurementConfig
     _DefaultName = "visitTableMeasurementTask"
 
-    def run(self, catalog, dataIds):
-        return self.measure.run(catalog, self.config.connections.metric, dataIds)
+    def run(self, catalog):
+        return self.measure.run(self.config.connections.metric, catalog)
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         inputs = butlerQC.get(inputRefs)
-        inputs['catalog'] = inputs['catalog'].get(parameters={'columns': self.config.columns})
-        inputs['dataIds'] = [butlerQC.registry.expandDataId(inputRefs.catalog.datasetRef.dataId)]
-        outputs = self.run(**inputs)
+        catalog = inputs['catalog'].get(parameters={'columns': self.config.columns})
+        outputs = self.run(catalog)
         if outputs.measurement is not None:
             butlerQC.put(outputs, outputRefs)
         else:

--- a/python/lsst/faro/measurement/VisitTableMeasurement.py
+++ b/python/lsst/faro/measurement/VisitTableMeasurement.py
@@ -4,11 +4,11 @@ import lsst.pex.config as pexConfig
 
 from lsst.faro.base.CatalogMeasurementBase import CatalogMeasurementBaseTaskConfig, CatalogMeasurementBaseTask
 
-__all__ = ("VisitTableMeasurementTaskConfig", "VisitTableMeasurementTask")
+__all__ = ("VisitTableMeasurementConfig", "VisitTableMeasurementTask")
 
 
-class VisitTableMeasurementTaskConnections(MetricConnections,
-                                           dimensions=("instrument", "visit", "band")):
+class VisitTableMeasurementConnections(MetricConnections,
+                                       dimensions=("instrument", "visit", "band")):
 
     catalog = pipeBase.connectionTypes.Input(doc="Source catalog for visit.",
                                              dimensions=("instrument", "visit", "band"),
@@ -22,14 +22,14 @@ class VisitTableMeasurementTaskConnections(MetricConnections,
                                                   name="metricvalue_{package}_{metric}")
 
 
-class VisitTableMeasurementTaskConfig(CatalogMeasurementBaseTaskConfig,
-                                      pipelineConnections=VisitTableMeasurementTaskConnections):
+class VisitTableMeasurementConfig(CatalogMeasurementBaseTaskConfig,
+                                  pipelineConnections=VisitTableMeasurementConnections):
     columns = pexConfig.Field(doc="Columns from sourceTable_visit to load.",
                               dtype=str, default='coord_ra, coord_dec')
 
 
 class VisitTableMeasurementTask(CatalogMeasurementBaseTask):
-    ConfigClass = VisitTableMeasurementTaskConfig
+    ConfigClass = VisitTableMeasurementConfig
     _DefaultName = "visitTableMeasurementTask"
 
     def run(self, catalog, dataIds):

--- a/python/lsst/faro/measurement/VisitTableMeasurement.py
+++ b/python/lsst/faro/measurement/VisitTableMeasurement.py
@@ -45,8 +45,8 @@ class VisitTableMeasurementConnections(MetricConnections,
 
 class VisitTableMeasurementConfig(CatalogMeasurementBaseTaskConfig,
                                   pipelineConnections=VisitTableMeasurementConnections):
-    columns = pexConfig.Field(doc="Columns from sourceTable_visit to load.",
-                              dtype=str, default='coord_ra, coord_dec')
+    columns = pexConfig.ListField(doc="Columns from sourceTable_visit to load.",
+                                  dtype=str, default=['coord_ra', 'coord_dec'])
 
 
 class VisitTableMeasurementTask(CatalogMeasurementBaseTask):
@@ -58,8 +58,7 @@ class VisitTableMeasurementTask(CatalogMeasurementBaseTask):
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         inputs = butlerQC.get(inputRefs)
-        columns = [_.strip() for _ in self.config.columns.split(',')]
-        inputs['catalog'] = inputs['catalog'].get(parameters={'columns': columns})
+        inputs['catalog'] = inputs['catalog'].get(parameters={'columns': self.config.columns})
         inputs['dataIds'] = [butlerQC.registry.expandDataId(inputRefs.catalog.datasetRef.dataId)]
         outputs = self.run(**inputs)
         if outputs.measurement is not None:

--- a/python/lsst/faro/measurement/__init__.py
+++ b/python/lsst/faro/measurement/__init__.py
@@ -10,6 +10,6 @@ from .VisitMeasurement import *
 from .TractMeasurement import *
 from .PatchMeasurement import *
 
-# Parquet table versions
+# Versions of metrics using parquet table inputs
 from .DetectorTableMeasurement import *
 from .VisitTableMeasurement import *

--- a/python/lsst/faro/measurement/__init__.py
+++ b/python/lsst/faro/measurement/__init__.py
@@ -9,3 +9,7 @@ from .DetectorMeasurement import *
 from .VisitMeasurement import *
 from .TractMeasurement import *
 from .PatchMeasurement import *
+
+# Parquet table versions
+from .DetectorTableMeasurement import *
+from .VisitTableMeasurement import *

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -42,19 +42,10 @@ class TaskTest(unittest.TestCase):
         catalog = SimpleCatalog.readFits(os.path.join(DATADIR, cat_file))
         return catalog
 
-    @classmethod
-    def setUpClass(cls):
-        '''This gets called once so can be used to set up
-           state that is used by all test methods.'''
-        super().setUpClass()
-        cls.file_map = {'CatalogMeasurementBaseTask':
-                        'src_HSC_i_HSC-I_903986_0_31_HSC_runs_ci_hsc_20210407T021858Z.fits'}
-
-    @classmethod
-    def tearDownClass(cls):
-        '''Delete any variables set in setUpClass.'''
-        del cls.file_map
-        super().tearDownClass()
+    def setUp(self):
+        """This is called immediately before calling each test method."""
+        self.file_map = {'CatalogMeasurementBaseTask':
+                         'src_HSC_i_HSC-I_903986_0_31_HSC_runs_ci_hsc_20210407T021858Z.fits'}
 
     def testCatalogMeasurementBaseTask(self):
         """Test run method of CatalogMeasurementBaseTask."""

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,106 @@
+# This file is part of faro.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import unittest
+import astropy.units as u
+
+from lsst.utils import getPackageDir
+from lsst.afw.table import SimpleCatalog
+
+from lsst.faro.base import CatalogMeasurementBaseConfig, CatalogMeasurementBaseTask
+from lsst.faro.measurement import (VisitTableMeasurementConfig, VisitTableMeasurementTask,
+                                   DetectorTableMeasurementConfig, DetectorTableMeasurementTask,
+                                   VisitMeasurementConfig, VisitMeasurementTask,
+                                   DetectorMeasurementConfig, DetectorMeasurementTask)
+
+DATADIR = os.path.join(getPackageDir('faro'), 'tests', 'data')
+
+
+class TaskTest(unittest.TestCase):
+
+    def load_data(self, key):
+        cat_file = self.file_map[key]
+        catalog = SimpleCatalog.readFits(os.path.join(DATADIR, cat_file))
+        return catalog
+
+    @classmethod
+    def setUpClass(cls):
+        '''This gets called once so can be used to set up
+           state that is used by all test methods.'''
+        super().setUpClass()
+        cls.file_map = {'CatalogMeasurementBaseTask':
+                        'src_HSC_i_HSC-I_903986_0_31_HSC_runs_ci_hsc_20210407T021858Z.fits'}
+
+    @classmethod
+    def tearDownClass(cls):
+        '''Delete any variables set in setUpClass.'''
+        del cls.file_map
+        super().tearDownClass()
+
+    def testCatalogMeasurementBaseTask(self):
+        """Test run method of CatalogMeasurementBaseTask."""
+        catalog = self.load_data('CatalogMeasurementBaseTask')
+        config = CatalogMeasurementBaseConfig()
+        t = CatalogMeasurementBaseTask(config)
+        outputs = t.run(catalog)
+        expected = 771 * u.count
+        self.assertEqual(outputs.measurement.quantity, expected)
+
+    def testVisitTableMeasurementTask(self):
+        """Test run method of VisitTableMeasurementTask."""
+        catalog = self.load_data('CatalogMeasurementBaseTask')
+        config = VisitTableMeasurementConfig()
+        t = VisitTableMeasurementTask(config)
+        outputs = t.run(catalog)
+        expected = 771 * u.count
+        self.assertEqual(outputs.measurement.quantity, expected)
+
+    def testDetectorTableMeasurementTask(self):
+        """Test run method of VisitTableMeasurementTask."""
+        catalog = self.load_data('CatalogMeasurementBaseTask')
+        config = DetectorTableMeasurementConfig()
+        t = DetectorTableMeasurementTask(config)
+        outputs = t.run(catalog)
+        expected = 771 * u.count
+        self.assertEqual(outputs.measurement.quantity, expected)
+
+    def testVisitMeasurementTask(self):
+        """Test run method of VisitMeasurementTask."""
+        catalog = self.load_data('CatalogMeasurementBaseTask')
+        config = VisitMeasurementConfig()
+        t = VisitMeasurementTask(config)
+        outputs = t.run(catalog)
+        expected = 771 * u.count
+        self.assertEqual(outputs.measurement.quantity, expected)
+
+    def testDetectorMeasurementTask(self):
+        """Test run method of DetectorMeasurementTask."""
+        catalog = self.load_data('CatalogMeasurementBaseTask')
+        config = DetectorMeasurementConfig()
+        t = DetectorMeasurementTask(config)
+        outputs = t.run(catalog)
+        expected = 771 * u.count
+        self.assertEqual(outputs.measurement.quantity, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds base classes that use `sourceTable_visit` parquet files as input to per-visit and per-detector metrics.

To test, run a command like

`pipetask --long-log run -b /repo/main/butler.yaml --register-dataset-types -p testpipe.yaml -d "visit=35892 AND skymap='hsc_rings_v1' AND instrument='HSC'" --output u/kbechtol/sourcetable_test -i HSC/runs/RC2/w_2021_18/DM-29973 --timeout 999999`

With testpipe.yaml pipeline file something like

```
description: Compute metrics from sourceTable_visit catalogs
tasks:
  nsrcMeasVisitTable:
    class: lsst.faro.measurement.VisitTableMeasurementTask
    config:
      connections.package: info
      connections.metric: nsrcMeasVisitTable
      python: |
        from lsst.faro.base import NumSourcesTask
        config.measure.retarget(NumSourcesTask)
        config.columns = 'coord_ra, coord_dec, visit'

description: Compute per-detector metrics from sourceTable_visit catalogs
tasks:
  nsrcMeasDetectorTable:
    class: lsst.faro.measurement.DetectorTableMeasurementTask
    config:
      connections.package: info
      connections.metric: nsrcMeasDetectorTable
      python: |
        from lsst.faro.base import NumSourcesTask
        config.measure.retarget(NumSourcesTask)
        config.columns = 'coord_ra, coord_dec, visit, detector'
```

In the current PR version, there are new base classes that use `sourceTable_visit` rather than replacing the previous base classes that use `src` catalogs, i.e., we retain both versions for now. Perhaps we should discuss at what point / if we want to completely replace the versions that use `src` catalogs. Another question for this PR is whether we want to add base classes for the object tables and for creating the matching catalogs, or whether we want those as separate PRs.

Currently, this PR does not have new/modified pipeline yaml files included.