### PR TITLE
DM-31381: Add config option for using reference catalog connection input

### DIFF
--- a/python/lsst/faro/measurement/DetectorMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorMeasurement.py
@@ -17,10 +17,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import lsst.pipe.base as pipeBase
-from lsst.verify.tasks import MetricConnections
 import lsst.pex.config as pexConfig
 
 from lsst.faro.base.CatalogMeasurementBase import (
+    CatalogMeasurementBaseConnections,
     CatalogMeasurementBaseConfig,
     CatalogMeasurementBaseTask,
 )
@@ -29,7 +29,7 @@ __all__ = ("DetectorMeasurementConfig", "DetectorMeasurementTask")
 
 
 class DetectorMeasurementConnections(
-    MetricConnections,
+    CatalogMeasurementBaseConnections,
     dimensions=("instrument", "visit", "detector", "band"),
     defaultTemplates={
         "photoCalibName": "calexp.photoCalib",

--- a/python/lsst/faro/measurement/MatchedCatalogMeasurement.py
+++ b/python/lsst/faro/measurement/MatchedCatalogMeasurement.py
@@ -19,9 +19,10 @@
 import traceback
 
 import lsst.pipe.base as pipeBase
-from lsst.verify.tasks import MetricConnections, MetricComputationError
+from lsst.verify.tasks import MetricComputationError
 
 from lsst.faro.base.CatalogMeasurementBase import (
+    CatalogMeasurementBaseConnections,
     CatalogMeasurementBaseConfig,
     CatalogMeasurementBaseTask,
 )
@@ -43,7 +44,7 @@ __all__ = (
 
 
 class PatchMatchedMeasurementConnections(
-    MetricConnections, dimensions=("tract", "patch", "band", "instrument", "skymap")
+    CatalogMeasurementBaseConnections, dimensions=("tract", "patch", "band", "instrument", "skymap")
 ):
     cat = pipeBase.connectionTypes.Input(
         doc="Input matched catalog.",
@@ -100,7 +101,7 @@ class TractMatchedMeasurementTask(CatalogMeasurementBaseTask):
 
 
 class PatchMatchedMultiBandMeasurementConnections(
-    MetricConnections, dimensions=("tract", "patch", "band", "instrument", "skymap")
+    CatalogMeasurementBaseConnections, dimensions=("tract", "patch", "band", "instrument", "skymap")
 ):
     cat = pipeBase.connectionTypes.Input(
         doc="Input matched catalog.",

--- a/python/lsst/faro/measurement/PatchMeasurement.py
+++ b/python/lsst/faro/measurement/PatchMeasurement.py
@@ -17,9 +17,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import lsst.pipe.base as pipeBase
-from lsst.verify.tasks import MetricConnections
 
 from lsst.faro.base.CatalogMeasurementBase import (
+    CatalogMeasurementBaseConnections,
     CatalogMeasurementBaseConfig,
     CatalogMeasurementBaseTask,
 )
@@ -32,7 +32,7 @@ __all__ = (
 
 
 class PatchMeasurementConnections(
-    MetricConnections, dimensions=("tract", "patch", "skymap", "band")
+    CatalogMeasurementBaseConnections, dimensions=("tract", "patch", "skymap", "band")
 ):
 
     cat = pipeBase.connectionTypes.Input(

--- a/python/lsst/faro/measurement/TractMeasurement.py
+++ b/python/lsst/faro/measurement/TractMeasurement.py
@@ -17,9 +17,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import lsst.pipe.base as pipeBase
-from lsst.verify.tasks import MetricConnections
 
 from lsst.faro.base.CatalogMeasurementBase import (
+    CatalogMeasurementBaseConnections,
     CatalogMeasurementBaseConfig,
     CatalogMeasurementBaseTask,
 )
@@ -35,7 +35,7 @@ __all__ = (
 
 
 class TractMeasurementConnections(
-    MetricConnections,
+    CatalogMeasurementBaseConnections,
     dimensions=("tract", "skymap", "band"),
     defaultTemplates={
         "coaddName": "deepCoadd",

--- a/python/lsst/faro/measurement/VisitMeasurement.py
+++ b/python/lsst/faro/measurement/VisitMeasurement.py
@@ -17,9 +17,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import lsst.pipe.base as pipeBase
-from lsst.verify.tasks import MetricConnections
 
 from lsst.faro.base.CatalogMeasurementBase import (
+    CatalogMeasurementBaseConnections,
     CatalogMeasurementBaseConfig,
     CatalogMeasurementBaseTask,
 )
@@ -28,7 +28,7 @@ __all__ = ("VisitMeasurementConfig", "VisitMeasurementTask")
 
 
 class VisitMeasurementConnections(
-    MetricConnections,
+    CatalogMeasurementBaseConnections,
     dimensions=("instrument", "visit", "band"),
     defaultTemplates={"photoCalibName": "calexp.photoCalib", "wcsName": "calexp.wcs"},
 ):


### PR DESCRIPTION
This PR makes all the measurement connections base classes inherit from `CatalogMeasurementBaseConnections`. Previously, there was an inconsistency where the measurement configuration base classes were inheriting from `CatalogMeasurementBaseConfig` but had the connections base classes inheriting from `MetricConnections`.