### PR TITLE
DM-32229: Update faro TExTasks to take parquet table as input

### DIFF
--- a/pipelines/measurement/measurement_tract.yaml
+++ b/pipelines/measurement/measurement_tract.yaml
@@ -10,8 +10,6 @@ tasks:
         config.measure.retarget(TExTask)
         config.measure.minSep = 0.25
         config.measure.maxSep = 1.0
-        config.measure.column = "slot_Shape"
-        config.measure.columnPsf = "slot_PsfShape"
         config.measure.shearConvention = False
   TE2:
     class: lsst.faro.measurement.TractMeasurementTask
@@ -23,6 +21,4 @@ tasks:
         config.measure.retarget(TExTask)
         config.measure.minSep = 5.0
         config.measure.maxSep = 20.0
-        config.measure.column = "slot_Shape"
-        config.measure.columnPsf = "slot_PsfShape"
         config.measure.shearConvention = False

--- a/pipelines/measurement/measurement_tract.yaml
+++ b/pipelines/measurement/measurement_tract.yaml
@@ -12,6 +12,7 @@ tasks:
         config.measure.maxSep = 1.0
         config.measure.column = "slot_Shape"
         config.measure.columnPsf = "slot_PsfShape"
+        config.measure.shearConvention = False
   TE2:
     class: lsst.faro.measurement.TractMeasurementTask
     config:
@@ -24,3 +25,4 @@ tasks:
         config.measure.maxSep = 20.0
         config.measure.column = "slot_Shape"
         config.measure.columnPsf = "slot_PsfShape"
+        config.measure.shearConvention = False

--- a/pipelines/measurement/measurement_tract.yaml
+++ b/pipelines/measurement/measurement_tract.yaml
@@ -10,6 +10,8 @@ tasks:
         config.measure.retarget(TExTask)
         config.measure.minSep = 0.25
         config.measure.maxSep = 1.0
+        config.measure.column = "slot_Shape"
+        config.measure.columnPsf = "slot_PsfShape"
   TE2:
     class: lsst.faro.measurement.TractMeasurementTask
     config:
@@ -20,3 +22,5 @@ tasks:
         config.measure.retarget(TExTask)
         config.measure.minSep = 5.0
         config.measure.maxSep = 20.0
+        config.measure.column = "slot_Shape"
+        config.measure.columnPsf = "slot_PsfShape"

--- a/pipelines/measurement/measurement_tract_table.yaml
+++ b/pipelines/measurement/measurement_tract_table.yaml
@@ -42,10 +42,6 @@ tasks:
       python: |
         from lsst.faro.measurement import TExTableTask
         config.measure.retarget(TExTableTask)
-        # config.columns = ["coord_ra", "coord_dec", "deblend_nChild"]
-        # config.columnsBand = ["ixx", "iyy", "ixy", "ixxPSF",
-        #                       "iyyPSF", "ixyPSF", "extendedness", "psfFlux",
-        #                       "psfFluxErr"]
         config.measure.minSep = 0.25
         config.measure.maxSep = 1.0
         config.measure.shearConvention = False
@@ -57,10 +53,6 @@ tasks:
       python: |
         from lsst.faro.measurement import TExTableTask
         config.measure.retarget(TExTableTask)
-        # config.columns = ["coord_ra", "coord_dec", "deblend_nChild"]
-        # config.columnsBand = ["ixx", "iyy", "ixy", "ixxPSF",
-        #                       "iyyPSF", "ixyPSF", "extendedness", "psfFlux",
-        #                       "psfFluxErr"]
         config.measure.minSep = 5.0
         config.measure.maxSep = 20.0
         config.measure.shearConvention = False

--- a/pipelines/measurement/measurement_tract_table.yaml
+++ b/pipelines/measurement/measurement_tract_table.yaml
@@ -1,10 +1,10 @@
 description: Compute metrics from objectTable_tract catalogs
 tasks:
-  nsrcMeasTractTable:
-    class: lsst.faro.measurement.TractTableMeasurementTask
-    config:
-      connections.package: info
-      connections.metric: nsrcMeasTractTable
+  # nsrcMeasTractTable:
+    # class: lsst.faro.measurement.TractTableMeasurementTask
+    # config:
+      # connections.package: info
+      # connections.metric: nsrcMeasTractTable
       # Reference dataset must be consistently specified 
       # in connections and reference object loader.
       # Reference datasets include:
@@ -13,9 +13,9 @@ tasks:
       # Examples to specify the reference dataset:
       # connections.refDataset: 'gaia_dr2_20200414'
       # connections.refDataset: 'ps1_pv3_3pi_20170110'
-      python: |
-        from lsst.faro.base import NumSourcesTask
-        config.measure.retarget(NumSourcesTask)
+      # python: |
+        # from lsst.faro.base import NumSourcesTask
+        # config.measure.retarget(NumSourcesTask)
         # Example configuration to apply proper motions for Gaia
         # config.referenceCatalogLoader.refObjLoader.ref_dataset_name = 'gaia_dr2_20200414'
         # config.referenceCatalogLoader.refObjLoader.requireProperMotion = True
@@ -34,3 +34,37 @@ tasks:
         #                                                            'config',
         #                                                            'colorterms.py'))
         # config.instrument: 'hsc'
+  TE1:
+    class: lsst.faro.measurement.TractTableMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: TE1_table
+      python: |
+        from lsst.faro.measurement import TExTableTask
+        config.measure.retarget(TExTableTask)
+        # config.measure.raColumn = "ra"
+        # config.measure.decColumn = "decl"
+        # config.columns = ["coord_ra", "coord_dec", "deblend_nChild"]
+        # config.columnsBand = ["ixx", "iyy", "ixy", "ixxPSF",
+        #                       "iyyPSF", "ixyPSF", "extendedness", "psfFlux",
+        #                       "psfFluxErr"]
+        config.measure.minSep = 0.25
+        config.measure.maxSep = 1.0
+        config.measure.shearConvention = False
+  TE2:
+    class: lsst.faro.measurement.TractTableMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: TE2_table
+      python: |
+        from lsst.faro.measurement import TExTableTask
+        config.measure.retarget(TExTableTask)
+        # config.measure.raColumn = "ra"
+        # config.measure.decColumn = "decl"
+        # config.columns = ["coord_ra", "coord_dec", "deblend_nChild"]
+        # config.columnsBand = ["ixx", "iyy", "ixy", "ixxPSF",
+        #                       "iyyPSF", "ixyPSF", "extendedness", "psfFlux",
+        #                       "psfFluxErr"]
+        config.measure.minSep = 5.0
+        config.measure.maxSep = 20.0
+        config.measure.shearConvention = False

--- a/pipelines/measurement/measurement_tract_table.yaml
+++ b/pipelines/measurement/measurement_tract_table.yaml
@@ -1,10 +1,10 @@
 description: Compute metrics from objectTable_tract catalogs
 tasks:
-  # nsrcMeasTractTable:
-    # class: lsst.faro.measurement.TractTableMeasurementTask
-    # config:
-      # connections.package: info
-      # connections.metric: nsrcMeasTractTable
+  nsrcMeasTractTable:
+    class: lsst.faro.measurement.TractTableMeasurementTask
+    config:
+      connections.package: info
+      connections.metric: nsrcMeasTractTable
       # Reference dataset must be consistently specified 
       # in connections and reference object loader.
       # Reference datasets include:
@@ -13,9 +13,9 @@ tasks:
       # Examples to specify the reference dataset:
       # connections.refDataset: 'gaia_dr2_20200414'
       # connections.refDataset: 'ps1_pv3_3pi_20170110'
-      # python: |
-        # from lsst.faro.base import NumSourcesTask
-        # config.measure.retarget(NumSourcesTask)
+      python: |
+        from lsst.faro.base import NumSourcesTask
+        config.measure.retarget(NumSourcesTask)
         # Example configuration to apply proper motions for Gaia
         # config.referenceCatalogLoader.refObjLoader.ref_dataset_name = 'gaia_dr2_20200414'
         # config.referenceCatalogLoader.refObjLoader.requireProperMotion = True
@@ -42,8 +42,6 @@ tasks:
       python: |
         from lsst.faro.measurement import TExTableTask
         config.measure.retarget(TExTableTask)
-        # config.measure.raColumn = "ra"
-        # config.measure.decColumn = "decl"
         # config.columns = ["coord_ra", "coord_dec", "deblend_nChild"]
         # config.columnsBand = ["ixx", "iyy", "ixy", "ixxPSF",
         #                       "iyyPSF", "ixyPSF", "extendedness", "psfFlux",
@@ -59,8 +57,6 @@ tasks:
       python: |
         from lsst.faro.measurement import TExTableTask
         config.measure.retarget(TExTableTask)
-        # config.measure.raColumn = "ra"
-        # config.measure.decColumn = "decl"
         # config.columns = ["coord_ra", "coord_dec", "deblend_nChild"]
         # config.columnsBand = ["ixx", "iyy", "ixy", "ixxPSF",
         #                       "iyyPSF", "ixyPSF", "extendedness", "psfFlux",

--- a/pipelines/measurement/measurement_visit.yaml
+++ b/pipelines/measurement/measurement_visit.yaml
@@ -18,6 +18,10 @@ tasks:
         config.measure.retarget(TExTask)
         config.measure.minSep = 0.25
         config.measure.maxSep = 5.0
+        config.measure.columnPsf = "slot_PsfShape"
+        config.measure.column = "slot_Shape"
+#        config.measure.columnPsf = "ext_shapeHSM_HsmPsfMoments"
+#        config.measure.column = "ext_shapeHSM_HsmSourceMoments"
   TE4:
     class: lsst.faro.measurement.VisitMeasurementTask
     config:
@@ -28,4 +32,7 @@ tasks:
         config.measure.retarget(TExTask)
         config.measure.minSep = 5.0
         config.measure.maxSep = 20.0
-
+        config.measure.columnPsf = "slot_PsfShape"
+        config.measure.column = "slot_Shape"
+#        config.measure.columnPsf = "ext_shapeHSM_HsmPsfMoments"
+#        config.measure.column = "ext_shapeHSM_HsmSourceMoments"

--- a/pipelines/measurement/measurement_visit_table.yaml
+++ b/pipelines/measurement/measurement_visit_table.yaml
@@ -45,6 +45,7 @@ tasks:
         "psfFlux","psfFluxErr","deblend_nChild"]
         config.measure.minSep = 0.25
         config.measure.maxSep = 5.0
+        config.measure.shearConvention = False
   TE4:
     class: lsst.faro.measurement.VisitTableMeasurementTask
     config:
@@ -57,4 +58,4 @@ tasks:
         "psfFlux","psfFluxErr","deblend_nChild"]
         config.measure.minSep = 5.0
         config.measure.maxSep = 20.0
-        
+        config.measure.shearConvention = False

--- a/pipelines/measurement/measurement_visit_table.yaml
+++ b/pipelines/measurement/measurement_visit_table.yaml
@@ -33,3 +33,26 @@ tasks:
         # config.referenceCatalogLoader.colorterms.load(os.path.join(getPackageDir('obs_subaru'),
         #                                                            'config',
         #                                                            'colorterms.py'))
+  TE3:
+    class: lsst.faro.measurement.VisitTableMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: TE3_table
+      python: |
+        from lsst.faro.measurement import TExTableTask
+        config.measure.retarget(TExTableTask)
+        config.columns = ["coord_ra","coord_dec","Ixx","Iyy","Ixy","IxxPsf","IyyPsf","extendedness", "Deblend_nChild"]
+        config.measure.minSep = 0.25
+        config.measure.maxSep = 5.0
+  TE4:
+    class: lsst.faro.measurement.VisitTableMeasurementTask
+    config:
+      connections.package: validate_drp
+      connections.metric: TE4_table
+      python: |
+        from lsst.faro.measurement import TExTableTask
+        config.measure.retarget(TExTableTask)
+        config.columns = ["coord_ra","coord_dec","Ixx","Iyy","Ixy","IxxPsf","IyyPsf","extendedness", "Deblend_nChild"]
+        config.measure.minSep = 5.0
+        config.measure.maxSep = 20.0
+        

--- a/pipelines/measurement/measurement_visit_table.yaml
+++ b/pipelines/measurement/measurement_visit_table.yaml
@@ -41,7 +41,8 @@ tasks:
       python: |
         from lsst.faro.measurement import TExTableTask
         config.measure.retarget(TExTableTask)
-        config.columns = ["coord_ra","coord_dec","Ixx","Iyy","Ixy","IxxPsf","IyyPsf","extendedness", "Deblend_nChild"]
+        config.columns = ["coord_ra","coord_dec","ixx","iyy","ixy","ixxPSF","iyyPSF","ixyPSF","extendedness", 
+        "psfFlux","psfFluxErr","deblend_nChild"]
         config.measure.minSep = 0.25
         config.measure.maxSep = 5.0
   TE4:
@@ -52,7 +53,8 @@ tasks:
       python: |
         from lsst.faro.measurement import TExTableTask
         config.measure.retarget(TExTableTask)
-        config.columns = ["coord_ra","coord_dec","Ixx","Iyy","Ixy","IxxPsf","IyyPsf","extendedness", "Deblend_nChild"]
+        config.columns = ["coord_ra","coord_dec","ixx","iyy","ixy","ixxPSF","iyyPSF","ixyPSF","extendedness", 
+        "psfFlux","psfFluxErr","deblend_nChild"]
         config.measure.minSep = 5.0
         config.measure.maxSep = 20.0
         

--- a/python/lsst/faro/measurement/MatchedCatalogMeasurement.py
+++ b/python/lsst/faro/measurement/MatchedCatalogMeasurement.py
@@ -47,7 +47,8 @@ __all__ = (
 
 
 class PatchMatchedMeasurementConnections(
-    CatalogMeasurementBaseConnections, dimensions=("tract", "patch", "band", "instrument", "skymap")
+    CatalogMeasurementBaseConnections,
+    dimensions=("tract", "patch", "band", "instrument", "skymap"),
 ):
     matchedCatalog = pipeBase.connectionTypes.Input(
         doc="Input matched catalog.",
@@ -104,7 +105,8 @@ class TractMatchedMeasurementTask(CatalogMeasurementBaseTask):
 
 
 class PatchMatchedMultiBandMeasurementConnections(
-    CatalogMeasurementBaseConnections, dimensions=("tract", "patch", "band", "instrument", "skymap")
+    CatalogMeasurementBaseConnections,
+    dimensions=("tract", "patch", "band", "instrument", "skymap"),
 ):
     matchedCatalogMulti = pipeBase.connectionTypes.Input(
         doc="Input matched catalog.",
@@ -132,7 +134,9 @@ class PatchMatchedMultiBandMeasurementTask(CatalogMeasurementBaseTask):
     _DefaultName = "patchMatchedMultiBandMeasurementTask"
 
     def run(self, matchedCatalogMulti, in_id, out_id):
-        return self.measure.run(self.config.connections.metric, matchedCatalogMulti, in_id, out_id)
+        return self.measure.run(
+            self.config.connections.metric, matchedCatalogMulti, in_id, out_id
+        )
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         """Do Butler I/O to provide in-memory objects for run.

--- a/python/lsst/faro/measurement/TractMeasurement.py
+++ b/python/lsst/faro/measurement/TractMeasurement.py
@@ -60,7 +60,7 @@ class TractMeasurementConnections(
         doc="Object catalog.",
         dimensions=("tract", "patch", "skymap", "band"),
         storageClass="SourceCatalog",
-        name="deepCoadd_forced_src",
+        name="deepCoadd_meas",
         multiple=True,
     )
 

--- a/python/lsst/faro/measurement/TractMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractMeasurementTasks.py
@@ -117,10 +117,10 @@ class TExConfig(Config):
     columnPsf = Field(
         doc="Column to use for PSF model shape moments",
         dtype=str,
-        default="base_SdssShape_psf",
+        default="slot_PsfShape",
     )
     column = Field(
-        doc="Column to use for shape moments", dtype=str, default="base_SdssShape"
+        doc="Column to use for shape moments", dtype=str, default="slot_Shape"
     )
     # Eventually want to add option to use only PSF reserve stars
 

--- a/python/lsst/faro/measurement/TractTableMeasurement.py
+++ b/python/lsst/faro/measurement/TractTableMeasurement.py
@@ -69,13 +69,14 @@ class TractTableMeasurementConfig(
     columns = pexConfig.ListField(
         doc="Band-independent columns from objectTable_tract to load.",
         dtype=str,
-        default=["coord_ra", "coord_dec", "detect_isPrimary"],
+        default=["coord_ra", "coord_dec", "detect_isPrimary", "deblend_nChild"],
     )
 
     columnsBand = pexConfig.ListField(
         doc="Band-specific columns from objectTable_tract to load.",
         dtype=str,
-        default=["PsFlux", "PsFluxErr"],
+        default=["psfFlux", "psfFluxErr", "extendedness", "ixx", "iyy", "ixy",
+                 "ixxPSF", "iyyPSF", "ixyPSF"],
     )
 
     instrument = pexConfig.Field(
@@ -97,7 +98,7 @@ class TractTableMeasurementTask(CatalogMeasurementBaseTask):
 
         columns = self.config.columns.list()
         for column in self.config.columnsBand:
-            columns.append(kwargs["band"] + column)
+            columns.append(kwargs["band"] + "_" + column)
         kwargs["catalog"] = inputs["catalog"].get(parameters={"columns": columns})
 
         if self.config.connections.refDataset != "":
@@ -178,7 +179,7 @@ class TractMultiBandTableMeasurementTask(TractTableMeasurementTask):
         columns = self.config.columns.list()
         for band in self.config.bands:
             for column in self.config.columnsBand:
-                columns.append(band + column)
+                columns.append(band + "_" + column)
         kwargs["catalog"] = inputs["catalog"].get(parameters={"columns": columns})
 
         if self.config.connections.refDataset != "":

--- a/python/lsst/faro/measurement/TractTableMeasurement.py
+++ b/python/lsst/faro/measurement/TractTableMeasurement.py
@@ -75,7 +75,7 @@ class TractTableMeasurementConfig(
     columnsBand = pexConfig.ListField(
         doc="Band-specific columns from objectTable_tract to load.",
         dtype=str,
-        default=["psfFlux", "psfFluxErr"],
+        default=["PsFlux", "PsFluxErr"],
     )
 
     instrument = pexConfig.Field(

--- a/python/lsst/faro/measurement/TractTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractTableMeasurementTasks.py
@@ -1,0 +1,99 @@
+# This file is part of faro.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from lsst.afw.table import SourceCatalog
+from lsst.pex.config import Config, Field
+from lsst.pipe.base import Struct, Task
+from lsst.verify import Measurement, Datum
+
+from lsst.faro.utils.stellar_locus import stellarLocusResid, calcQuartileClippedStats
+from lsst.faro.utils.matcher import makeMatchedPhotom
+from lsst.faro.utils.extinction_corr import extinction_corr
+from lsst.faro.utils.tex_table import calculateTEx
+from lsst.faro.utils.calibrated_catalog import CalibratedCatalog
+
+import astropy.units as u
+import numpy as np
+from typing import Dict, List
+
+__all__ = ("TExTableConfig", "TExTableTask")
+
+
+class TExTableConfig(Config):
+    minSep = Field(
+        doc="Inner radius of the annulus in arcmin", dtype=float, default=0.25
+    )
+    maxSep = Field(
+        doc="Outer radius of the annulus in arcmin", dtype=float, default=1.0
+    )
+    nbins = Field(doc="Number of log-spaced angular bins", dtype=int, default=10)
+    rhoStat = Field(doc="Rho statistic to be computed", dtype=int, default=1)
+    shearConvention = Field(
+        doc="Use shear ellipticity convention rather than distortion",
+        dtype=bool,
+        default=False,
+    )
+    raColumn = Field(doc="RA column",dtype=str, default="ra_coord")
+    # Eventually want to add option to use only PSF reserve stars
+
+
+class TExTableTask(Task):
+    ConfigClass = TExTableConfig
+    _DefaultName = "TExTableTask"
+
+    def run(
+        self, metricName, catalog
+    ):
+        import pdb; pdb.set_trace()
+
+        bands = data.keys()
+        if len(bands) != 1:
+            raise RuntimeError(f'TEx task got bands: {bands} but expecting exactly one')
+        else:
+            data = data[list(bands)[0]]
+
+        self.log.info("Measuring %s", metricName)
+
+        result = calculateTEx(data, self.config)
+        if "corr" not in result.keys():
+            return Struct(measurement=Measurement(metricName, np.nan * u.Unit("")))
+
+        writeExtras = True
+        if writeExtras:
+            extras = {}
+            extras["radius"] = Datum(
+                result["radius"], label="radius", description="Separation (arcmin)."
+            )
+            extras["corr"] = Datum(
+                result["corr"], label="Correlation", description="Correlation."
+            )
+            extras["corrErr"] = Datum(
+                result["corrErr"],
+                label="Correlation Uncertianty",
+                description="Correlation Uncertainty.",
+            )
+        else:
+            extras = None
+        return Struct(
+            measurement=Measurement(
+                metricName, np.mean(np.abs(result["corr"])), extras=extras
+            )
+        )

--- a/python/lsst/faro/measurement/TractTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractTableMeasurementTasks.py
@@ -53,16 +53,16 @@ class TExTableConfig(Config):
     )
     raColumn = Field(doc="RA column", dtype=str, default="coord_ra")
     decColumn = Field(doc="Dec column", dtype=str, default="coord_dec")
-    ixxColumn = Field(doc="Ixx column", dtype=str, default="Ixx")
-    ixyColumn = Field(doc="Ixy column", dtype=str, default="Ixy")
-    iyyColumn = Field(doc="Iyy column", dtype=str, default="Iyy")
-    ixxPsfColumn = Field(doc="Ixx PSF column", dtype=str, default="IxxPsf")
-    ixyPsfColumn = Field(doc="Ixy PSF column", dtype=str, default="IxyPsf")
-    iyyPsfColumn = Field(doc="Iyy PSF column", dtype=str, default="IyyPsf")
+    ixxColumn = Field(doc="Ixx column", dtype=str, default="ixx")
+    ixyColumn = Field(doc="Ixy column", dtype=str, default="ixy")
+    iyyColumn = Field(doc="Iyy column", dtype=str, default="iyy")
+    ixxPsfColumn = Field(doc="Ixx PSF column", dtype=str, default="ixxPSF")
+    ixyPsfColumn = Field(doc="Ixy PSF column", dtype=str, default="ixyPSF")
+    iyyPsfColumn = Field(doc="Iyy PSF column", dtype=str, default="iyyPSF")
     extendednessColumn = Field(doc="Extendedness column", dtype=str, default="extendedness")
-    psfFluxColumn = Field(doc="PsfFlux column", dtype=str, default="PsfFlux")
-    psfFluxErrColumn = Field(doc="PsfFluxErr column", dtype=str, default="PsfFluxErr")
-    deblend_nChildColumn = Field(doc="nChild column", dtype=str, default="Deblend_nChild")
+    psfFluxColumn = Field(doc="PsfFlux column", dtype=str, default="psfFlux")
+    psfFluxErrColumn = Field(doc="PsfFluxErr column", dtype=str, default="psfFluxErr")
+    deblend_nChildColumn = Field(doc="nChild column", dtype=str, default="deblend_nChild")
     # Eventually want to add option to use only PSF reserve stars
 
 
@@ -73,17 +73,10 @@ class TExTableTask(Task):
     def run(
         self, metricName, catalog
     ):
-        import pdb; pdb.set_trace()
-
-        bands = data.keys()
-        if len(bands) != 1:
-            raise RuntimeError(f'TEx task got bands: {bands} but expecting exactly one')
-        else:
-            data = data[list(bands)[0]]
 
         self.log.info("Measuring %s", metricName)
 
-        result = calculateTEx(data, self.config)
+        result = calculateTEx(catalog, self.config)
         if "corr" not in result.keys():
             return Struct(measurement=Measurement(metricName, np.nan * u.Unit("")))
 

--- a/python/lsst/faro/measurement/TractTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractTableMeasurementTasks.py
@@ -38,6 +38,20 @@ __all__ = ("TExTableConfig", "TExTableTask")
 
 
 class TExTableConfig(Config):
+    """Class to organize the yaml configuration parameters to be passed to 
+    TExTableTask when using a parquet table input. All values needed to perform 
+    TExTableTask have default values set below. 
+    
+    Optional Input (yaml file)
+    ----------
+    Column names specified as str in yaml configuration for TeX task. These are 
+    the desired column names to be passed to the calcuation. If you wish to use
+    values other than the default values specified below, add the following e.g. 
+    line to the yaml file: 
+    
+    config.measure.raColumn = "coord_ra_new"
+    """
+    
     minSep = Field(
         doc="Inner radius of the annulus in arcmin", dtype=float, default=0.25
     )
@@ -49,7 +63,7 @@ class TExTableConfig(Config):
     shearConvention = Field(
         doc="Use shear ellipticity convention rather than distortion",
         dtype=bool,
-        default=False,
+        default=True,
     )
     raColumn = Field(doc="RA column", dtype=str, default="coord_ra")
     decColumn = Field(doc="Dec column", dtype=str, default="coord_dec")
@@ -67,6 +81,18 @@ class TExTableConfig(Config):
 
 
 class TExTableTask(Task):
+    """Class to perform the tex_table calculation on a parquet table data 
+    object. 
+    
+    Parameters
+    ----------
+    None    
+    
+    Output:
+    ----------
+    TEx metric with defined configuration.
+    """
+
     ConfigClass = TExTableConfig
     _DefaultName = "TExTableTask"
 

--- a/python/lsst/faro/measurement/TractTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractTableMeasurementTasks.py
@@ -51,7 +51,18 @@ class TExTableConfig(Config):
         dtype=bool,
         default=False,
     )
-    raColumn = Field(doc="RA column",dtype=str, default="ra_coord")
+    raColumn = Field(doc="RA column", dtype=str, default="ra_coord")
+    decColumn = Field(doc="Dec column", dtype=str, default="dec_coord")
+    ixxColumn = Field(doc="Ixx column", dtype=str, default="Ixx")
+    ixyColumn = Field(doc="Ixy column", dtype=str, default="Ixy")
+    iyyColumn = Field(doc="Iyy column", dtype=str, default="Iyy")
+    ixxPsfColumn = Field(doc="Ixx PSF column", dtype=str, default="IxxPsf")
+    ixyPsfColumn = Field(doc="Ixy PSF column", dtype=str, default="IxyPsf")
+    iyyPsfColumn = Field(doc="Iyy PSF column", dtype=str, default="IyyPsf")
+    extendednessColumn = Field(doc="Extendedness column", dtype=str, default="extendedness")
+    psfFluxColumn = Field(doc="PsfFlux column", dtype=str, default="PsfFlux")
+    psfFluxErrColumn = Field(doc="PsfFlux column", dtype=str, default="PsfFluxErr")
+    deblend_nChildColumn = Field(doc="nChild column", dtype=str, default="Deblend_nChild")
     # Eventually want to add option to use only PSF reserve stars
 
 

--- a/python/lsst/faro/measurement/TractTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractTableMeasurementTasks.py
@@ -51,8 +51,8 @@ class TExTableConfig(Config):
         dtype=bool,
         default=False,
     )
-    raColumn = Field(doc="RA column", dtype=str, default="ra_coord")
-    decColumn = Field(doc="Dec column", dtype=str, default="dec_coord")
+    raColumn = Field(doc="RA column", dtype=str, default="coord_ra")
+    decColumn = Field(doc="Dec column", dtype=str, default="coord_dec")
     ixxColumn = Field(doc="Ixx column", dtype=str, default="Ixx")
     ixyColumn = Field(doc="Ixy column", dtype=str, default="Ixy")
     iyyColumn = Field(doc="Iyy column", dtype=str, default="Iyy")
@@ -61,7 +61,7 @@ class TExTableConfig(Config):
     iyyPsfColumn = Field(doc="Iyy PSF column", dtype=str, default="IyyPsf")
     extendednessColumn = Field(doc="Extendedness column", dtype=str, default="extendedness")
     psfFluxColumn = Field(doc="PsfFlux column", dtype=str, default="PsfFlux")
-    psfFluxErrColumn = Field(doc="PsfFlux column", dtype=str, default="PsfFluxErr")
+    psfFluxErrColumn = Field(doc="PsfFluxErr column", dtype=str, default="PsfFluxErr")
     deblend_nChildColumn = Field(doc="nChild column", dtype=str, default="Deblend_nChild")
     # Eventually want to add option to use only PSF reserve stars
 

--- a/python/lsst/faro/measurement/__init__.py
+++ b/python/lsst/faro/measurement/__init__.py
@@ -14,6 +14,7 @@ from .PatchMeasurement import *
 from .DetectorTableMeasurement import *
 from .VisitTableMeasurement import *
 from .TractTableMeasurement import *
+from .TractTableMeasurementTasks import *
 from .PatchTableMeasurement import *
 from .ForcedSourceTableMeasurement import *
 from .TractTableMeasurementTasks import *

--- a/python/lsst/faro/measurement/__init__.py
+++ b/python/lsst/faro/measurement/__init__.py
@@ -16,3 +16,4 @@ from .VisitTableMeasurement import *
 from .TractTableMeasurement import *
 from .PatchTableMeasurement import *
 from .ForcedSourceTableMeasurement import *
+from .TractTableMeasurementTasks import *

--- a/python/lsst/faro/measurement/__init__.py
+++ b/python/lsst/faro/measurement/__init__.py
@@ -17,4 +17,3 @@ from .TractTableMeasurement import *
 from .TractTableMeasurementTasks import *
 from .PatchTableMeasurement import *
 from .ForcedSourceTableMeasurement import *
-from .TractTableMeasurementTasks import *

--- a/python/lsst/faro/utils/tex.py
+++ b/python/lsst/faro/utils/tex.py
@@ -43,8 +43,7 @@ __all__ = (
 
 
 class TraceSize(object):
-    """Functor to calculate trace radius size for sources.
-    """
+    """Functor to calculate trace radius size for sources."""
 
     def __init__(self, column):
         self.column = column
@@ -435,8 +434,7 @@ def corrSpin2(
 
 
 def calculateTEx(data: List[CalibratedCatalog], config):
-    """Compute ellipticity residual correlation metrics.
-    """
+    """Compute ellipticity residual correlation metrics."""
 
     catalog = mergeCatalogs(
         [x.catalog for x in data],
@@ -458,7 +456,7 @@ def calculateTEx(data: List[CalibratedCatalog], config):
     nMinSources = 50
     if np.sum(selection) < nMinSources:
         return {"nomeas": np.nan * u.Unit("")}
-        
+
     treecorrKwargs = dict(
         nbins=config.nbins,
         min_sep=config.minSep,
@@ -466,7 +464,10 @@ def calculateTEx(data: List[CalibratedCatalog], config):
         sep_units="arcmin",
     )
     rhoStatistics = RhoStatistics(
-        config.column, config.columnPsf, shearConvention=config.shearConvention, **treecorrKwargs
+        config.column,
+        config.columnPsf,
+        shearConvention=config.shearConvention,
+        **treecorrKwargs
     )
     xy = rhoStatistics(catalog[selection])[config.rhoStat]
 

--- a/python/lsst/faro/utils/tex.py
+++ b/python/lsst/faro/utils/tex.py
@@ -458,9 +458,7 @@ def calculateTEx(data: List[CalibratedCatalog], config):
     nMinSources = 50
     if np.sum(selection) < nMinSources:
         return {"nomeas": np.nan * u.Unit("")}
-    
-    import pdb; pdb.set_trace()
-    
+        
     treecorrKwargs = dict(
         nbins=config.nbins,
         min_sep=config.minSep,
@@ -468,7 +466,7 @@ def calculateTEx(data: List[CalibratedCatalog], config):
         sep_units="arcmin",
     )
     rhoStatistics = RhoStatistics(
-        config.column, config.columnPsf, config.shearConvention, **treecorrKwargs
+        config.column, config.columnPsf, shearConvention=config.shearConvention, **treecorrKwargs
     )
     xy = rhoStatistics(catalog[selection])[config.rhoStat]
 

--- a/python/lsst/faro/utils/tex.py
+++ b/python/lsst/faro/utils/tex.py
@@ -82,8 +82,8 @@ class E1(object):
     ----------
     column : `str`
         The name of the shape measurement algorithm. It should be one of
-        ("base_SdssShape", "ext_shapeHSM_HsmSourceMoments") or
-        ("base_SdssShape_psf", "ext_shapeHSM_HsmPsfMoments") for corresponding
+        ("slot_Shape", "ext_shapeHSM_HsmSourceMoments") or
+        ("slot_PsfShape", "ext_shapeHSM_HsmPsfMoments") for corresponding
         PSF ellipticities.
     unitScale : `float`, optional
         A numerical scaling factor to multiply the ellipticity.
@@ -118,8 +118,8 @@ class E2(object):
     ----------
     column : `str`
         The name of the shape measurement algorithm. It should be one of
-        ("base_SdssShape", "ext_shapeHSM_HsmSourceMoments") or
-        ("base_SdssShape_psf", "ext_shapeHSM_HsmPsfMoments") for corresponding
+        ("slot_Shape", "ext_shapeHSM_HsmSourceMoments") or
+        ("slot_PsfShape", "ext_shapeHSM_HsmPsfMoments") for corresponding
         PSF ellipticities.
     unitScale : `float`, optional
         A numerical scaling factor to multiply the ellipticity.
@@ -155,10 +155,10 @@ class E1Resids(object):
     ----------
     column : `str`
         The name of the shape measurement algorithm. It should be one of
-        ("base_SdssShape", "ext_shapeHSM_HsmSourceMoments").
+        ("slot_Shape", "ext_shapeHSM_HsmSourceMoments").
     psfColumn : `str`
         The name used for PSF shape measurements from the same algorithm.
-        It must be one of ("base_SdssShape_psf", "ext_shapeHSM_HsmPsfMoments")
+        It must be one of ("slot_PsfShape", "ext_shapeHSM_HsmPsfMoments")
         and correspond to the algorithm name specified for ``column``.
     unitScale : `float`, optional
         A numerical scaling factor to multiply both the object and PSF
@@ -196,10 +196,10 @@ class E2Resids(object):
     ----------
     column : `str`
         The name of the shape measurement algorithm. It should be one of
-        ("base_SdssShape", "ext_shapeHSM_HsmSourceMoments").
+        ("slot_Shape", "ext_shapeHSM_HsmSourceMoments").
     psfColumn : `str`
         The name used for PSF shape measurements from the same algorithm.
-        It must be one of ("base_SdssShape_psf", "ext_shapeHSM_HsmPsfMoments")
+        It must be one of ("slot_PsfShape", "ext_shapeHSM_HsmPsfMoments")
         and correspond to the algorithm name specified for ``column``.
     unitScale : `float`, optional
         A numerical scaling factor to multiply both the object and PSF
@@ -238,10 +238,10 @@ class RhoStatistics(object):
     ----------
     column : `str`
         The name of the shape measurement algorithm. It should be one of
-        ("base_SdssShape", "ext_shapeHSM_HsmSourceMoments").
+        ("slot_Shape", "ext_shapeHSM_HsmSourceMoments").
     psfColumn : `str`
         The name used for PSF shape measurements from the same algorithm.
-        It must be one of ("base_SdssShape_psf", "ext_shapeHSM_HsmPsfMoments")
+        It must be one of ("slot_PsfShape", "ext_shapeHSM_HsmPsfMoments")
         and correspond to the algorithm name specified for ``column``.
     shearConvention: `bool`, optional
         Option to use shear convention. When set to False, the distortion

--- a/python/lsst/faro/utils/tex.py
+++ b/python/lsst/faro/utils/tex.py
@@ -458,7 +458,9 @@ def calculateTEx(data: List[CalibratedCatalog], config):
     nMinSources = 50
     if np.sum(selection) < nMinSources:
         return {"nomeas": np.nan * u.Unit("")}
-
+    
+    import pdb; pdb.set_trace()
+    
     treecorrKwargs = dict(
         nbins=config.nbins,
         min_sep=config.minSep,

--- a/python/lsst/faro/utils/tex_table.py
+++ b/python/lsst/faro/utils/tex_table.py
@@ -50,7 +50,7 @@ class TraceSize(object):
 
     def __call__(self, catalog):
         srcSize = np.sqrt(
-            0.5 * (catalog[ixxColumn] + catalog[iyyColumn])
+            0.5 * (catalog[self.ixxColumn] + catalog[self.iyyColumn])
         )
         return np.array(srcSize)
 
@@ -66,8 +66,8 @@ class PsfTraceSizeDiff(object):
         self.ixxPsfColumn = ixxPsfColumn
         self.iyyPsfColumn = iyyPsfColumn
         
-        self.traceSizeFunc = TraceSize(self.ixxColumn,self.iyyColumn)
-        self.psfTraceSizeFunc = TraceSize(self.ixxPsfColumn,self.iyyPsfColumn)
+        self.traceSizeFunc = TraceSize(self.ixxColumn, self.iyyColumn)
+        self.psfTraceSizeFunc = TraceSize(self.ixxPsfColumn, self.iyyPsfColumn)
         
     def __call__(self, catalog):
         srcSize = traceSizeFunc(catalog)
@@ -106,10 +106,10 @@ class E1(object):
         self.shearConvention = shearConvention
 
     def __call__(self, catalog):
-        xx = catalog[ixxColumn]
-        yy = catalog[iyyColumn]
+        xx = catalog[self.ixxColumn]
+        yy = catalog[self.iyyColumn]
         if self.shearConvention:
-            xy = catalog[ixyColumn]
+            xy = catalog[self.ixyColumn]
             e1 = (xx - yy) / (xx + yy + 2.0 * np.sqrt(xx * yy - xy ** 2))
         else:
             e1 = (xx - yy) / (xx + yy)
@@ -146,9 +146,9 @@ class E2(object):
         self.shearConvention = shearConvention
 
     def __call__(self, catalog):
-        xx = catalog[ixxColumn]
-        yy = catalog[iyyColumn]
-        xy = catalog[ixyColumn]
+        xx = catalog[self.ixxColumn]
+        yy = catalog[self.iyyColumn]
+        xy = catalog[self.ixyColumn]
         if self.shearConvention:
             e2 = (2.0 * xy) / (xx + yy + 2.0 * np.sqrt(xx * yy - xy ** 2))
         else:
@@ -492,8 +492,7 @@ def calculateTEx(catalog, config):
     yaml specifications  https://github.com/lsst/obs_lsst/blob/073901ab35efe5253ca64aeb14a290692ae400bd/policy/imsim/Source.yaml#L208-L226
     """
 
-    # Filtering should be pulled out into a separate function for standard quality selections
-    # TO-DO: update column names following https://github.com/yalsayyad/dm_notebooks/blob/master/object-table/ci_imsim_check_for_DRP_Table_and_Column.ipynb
+    # TO-DO: Filtering should be pulled out into a separate function for standard quality selections
     snrMin = 50
     selection = (
         (catalog[config.extendednessColumn] < 0.5)

--- a/python/lsst/faro/utils/tex_table.py
+++ b/python/lsst/faro/utils/tex_table.py
@@ -98,7 +98,7 @@ class E1(object):
     """
 
     def __init__(self, ixxColumn, iyyColumn, 
-                 ixyColumn=ixyColumn, unitScale=1.0, shearConvention=False):
+                 ixyColumn, unitScale=1.0, shearConvention=False):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
         self.ixyColumn = ixyColumn
@@ -186,7 +186,7 @@ class E1Resids(object):
     """
 
     def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn, 
-                 ixyColumn=ixyColumn, ixyPsfColumn=ixyPsfColumn, unitScale=1.0, 
+                 ixyColumn, ixyPsfColumn, unitScale=1.0, 
                  shearConvention=False):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
@@ -241,7 +241,7 @@ class E2Resids(object):
     """
 
     def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn, 
-                 ixyColumn=ixyColumn, ixyPsfColumn=ixyPsfColumn, unitScale=1.0, 
+                 ixyColumn, ixyPsfColumn, unitScale=1.0, 
                  shearConvention=False):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
@@ -295,8 +295,8 @@ class RhoStatistics(object):
     """
 
     def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn,
-                 raColumn, decColumn, ixyColumn=ixyColumn, 
-                 ixyPsfColumn=ixyPsfColumn, shearConvention=False, **kwargs):
+                 raColumn, decColumn, ixyColumn, 
+                 ixyPsfColumn, shearConvention=False, **kwargs):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
         self.ixyColumn = ixyColumn
@@ -307,21 +307,21 @@ class RhoStatistics(object):
         self.raColumn = raColumn
         self.decColumn = decColumn
         self.e1Func = E1(self.ixxPsfColumn, self.iyyPsfColumn, 
-                         ixyPsfColumn=self.ixyPsfColumn, 
+                         self.ixyPsfColumn, 
                          shearConvention=self.shearConvention)
         self.e2Func = E2(self.ixxPsfColumn, self.iyyPsfColumn, 
-                         ixyPsfColumn=self.ixyPsfColumn, 
+                         self.ixyPsfColumn, 
                          shearConvention=self.shearConvention)
         self.e1ResidsFunc = E1Resids(self.ixxColumn, self.iyyColumn, 
                                      self.ixxPsfColumn, self.iyyPsfColumn, 
-                                     ixyColumn=self.ixyColumn, 
-                                     ixyPsfColumn=self.ixyPsfColumn,
+                                     self.ixyColumn, 
+                                     self.ixyPsfColumn,
                                      shearConvention=self.shearConvention
         )
         self.e2ResidsFunc = E2Resids(self.ixxColumn, self.iyyColumn, 
                                      self.ixxPsfColumn, self.iyyPsfColumn, 
-                                     ixyColumn=self.ixyColumn, 
-                                     ixyPsfColumn=self.ixyPsfColumn,
+                                     self.ixyColumn, 
+                                     self.ixyPsfColumn,
                                      shearConvention=self.shearConvention 
         )
         self.traceSizeFunc = TraceSize(self.ixxColumn,self.iyyColumn)
@@ -520,8 +520,8 @@ def calculateTEx(catalog, config):
     rhoStatisticsFunc = RhoStatistics(config.ixxColumn, config.iyyColumn, 
                                       config.ixxPsfColumn, config.iyyPsfColumn,
                                       config.raColumn, config.decColumn,
-                                      ixyColumn=config.ixyColumn, 
-                                      ixyPsfColumn=config.ixyPsfColumn,
+                                      config.ixyColumn, 
+                                      config.ixyPsfColumn,
                                       shearConvention=config.shearConvention, 
                                       **treecorrKwargs
     )

--- a/python/lsst/faro/utils/tex_table.py
+++ b/python/lsst/faro/utils/tex_table.py
@@ -507,6 +507,8 @@ def calculateTEx(catalog, config):
     if np.sum(selection) < nMinSources:
         return {"nomeas": np.nan * u.Unit("")}
 
+    import pdb; pdb.set_trace()
+
     treecorrKwargs = dict(
         nbins=config.nbins,
         min_sep=config.minSep,

--- a/python/lsst/faro/utils/tex_table.py
+++ b/python/lsst/faro/utils/tex_table.py
@@ -489,7 +489,7 @@ def corrSpin2(
 
 def calculateTEx(catalog, config):
     """Compute ellipticity residual correlation metrics using parquet table as input. New column names based on these
-    yaml specifications  https://github.com/lsst/obs_lsst/blob/073901ab35efe5253ca64aeb14a290692ae400bd/policy/imsim/Source.yaml#L208-L226
+    yaml specifications  https://github.com/lsst/obs_lsst/blob/073901ab35efe5253ca64aeb14a290692ae400bd/policy/imsim/Source.yaml#L208-L226.
     """
 
     # TO-DO: Filtering should be pulled out into a separate function for standard quality selections
@@ -506,8 +506,6 @@ def calculateTEx(catalog, config):
     nMinSources = 50
     if np.sum(selection) < nMinSources:
         return {"nomeas": np.nan * u.Unit("")}
-
-    import pdb; pdb.set_trace()
 
     treecorrKwargs = dict(
         nbins=config.nbins,

--- a/python/lsst/faro/utils/tex_table.py
+++ b/python/lsst/faro/utils/tex_table.py
@@ -40,7 +40,7 @@ __all__ = (
 
 
 class TraceSize(object):
-    """Functor to calculate trace radius size for sources. ixxColumn and 
+    """Functor to calculate trace radius size for sources. ixxColumn and
     iyyColumn are strings and must be defined in the Task Config.
     """
 
@@ -65,13 +65,13 @@ class PsfTraceSizeDiff(object):
         self.iyyColumn = iyyColumn
         self.ixxPsfColumn = ixxPsfColumn
         self.iyyPsfColumn = iyyPsfColumn
-        
+
         self.traceSizeFunc = TraceSize(self.ixxColumn, self.iyyColumn)
         self.psfTraceSizeFunc = TraceSize(self.ixxPsfColumn, self.iyyPsfColumn)
-        
+
     def __call__(self, catalog):
-        srcSize = traceSizeFunc(catalog)
-        psfSize = psfTraceSizeFunc(catalog)
+        srcSize = self.traceSizeFunc(catalog)
+        psfSize = self.psfTraceSizeFunc(catalog)
         sizeDiff = 100 * (srcSize - psfSize) / (0.5 * (srcSize + psfSize))
         return np.array(sizeDiff)
 
@@ -97,7 +97,7 @@ class E1(object):
         A numpy array of e1 ellipticity values.
     """
 
-    def __init__(self, ixxColumn, iyyColumn, 
+    def __init__(self, ixxColumn, iyyColumn,
                  ixyColumn, unitScale=1.0, shearConvention=False):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
@@ -137,7 +137,7 @@ class E2(object):
         A numpy array of e2 ellipticity values.
     """
 
-    def __init__(self, ixxColumn, 
+    def __init__(self, ixxColumn,
                  iyyColumn, ixyColumn, unitScale=1.0, shearConvention=False):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
@@ -185,8 +185,8 @@ class E1Resids(object):
         A numpy array of e1 residual ellipticity values.
     """
 
-    def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn, 
-                 ixyColumn, ixyPsfColumn, unitScale=1.0, 
+    def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn,
+                 ixyColumn, ixyPsfColumn, unitScale=1.0,
                  shearConvention=False):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
@@ -199,9 +199,9 @@ class E1Resids(object):
         self.shearConvention = shearConvention
 
     def __call__(self, catalog):
-        srcE1func = E1(self.ixxColumn, self.iyyColumn, self.ixyColumn, 
-                      self.unitScale, self.shearConvention)
-        psfE1func = E1(self.ixxPsfColumn, self.iyyPsfColumn, self.ixyPsfColumn, 
+        srcE1func = E1(self.ixxColumn, self.iyyColumn, self.ixyColumn,
+                       self.unitScale, self.shearConvention)
+        psfE1func = E1(self.ixxPsfColumn, self.iyyPsfColumn, self.ixyPsfColumn,
                        self.unitScale, self.shearConvention)
 
         srcE1 = srcE1func(catalog)
@@ -240,8 +240,8 @@ class E2Resids(object):
         A numpy array of e2 residual ellipticity values.
     """
 
-    def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn, 
-                 ixyColumn, ixyPsfColumn, unitScale=1.0, 
+    def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn,
+                 ixyColumn, ixyPsfColumn, unitScale=1.0,
                  shearConvention=False):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
@@ -253,9 +253,9 @@ class E2Resids(object):
         self.shearConvention = shearConvention
 
     def __call__(self, catalog):
-        srcE2func = E2(self.ixxColumn, self.iyyColumn, self.ixyColumn, 
-                      self.unitScale, self.shearConvention)
-        psfE2func = E2(self.ixxPsfColumn, self.iyyPsfColumn, self.ixyPsfColumn, 
+        srcE2func = E2(self.ixxColumn, self.iyyColumn, self.ixyColumn,
+                       self.unitScale, self.shearConvention)
+        psfE2func = E2(self.ixxPsfColumn, self.iyyPsfColumn, self.ixyPsfColumn,
                        self.unitScale, self.shearConvention)
 
         srcE2 = srcE2func(catalog)
@@ -295,7 +295,7 @@ class RhoStatistics(object):
     """
 
     def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn,
-                 raColumn, decColumn, ixyColumn, 
+                 raColumn, decColumn, ixyColumn,
                  ixyPsfColumn, shearConvention=False, **kwargs):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
@@ -306,26 +306,24 @@ class RhoStatistics(object):
         self.shearConvention = shearConvention
         self.raColumn = raColumn
         self.decColumn = decColumn
-        self.e1Func = E1(self.ixxPsfColumn, self.iyyPsfColumn, 
-                         self.ixyPsfColumn, 
+        self.e1Func = E1(self.ixxPsfColumn, self.iyyPsfColumn,
+                         self.ixyPsfColumn,
                          shearConvention=self.shearConvention)
-        self.e2Func = E2(self.ixxPsfColumn, self.iyyPsfColumn, 
-                         self.ixyPsfColumn, 
+        self.e2Func = E2(self.ixxPsfColumn, self.iyyPsfColumn,
+                         self.ixyPsfColumn,
                          shearConvention=self.shearConvention)
-        self.e1ResidsFunc = E1Resids(self.ixxColumn, self.iyyColumn, 
-                                     self.ixxPsfColumn, self.iyyPsfColumn, 
-                                     self.ixyColumn, 
+        self.e1ResidsFunc = E1Resids(self.ixxColumn, self.iyyColumn,
+                                     self.ixxPsfColumn, self.iyyPsfColumn,
+                                     self.ixyColumn,
                                      self.ixyPsfColumn,
-                                     shearConvention=self.shearConvention
-        )
-        self.e2ResidsFunc = E2Resids(self.ixxColumn, self.iyyColumn, 
-                                     self.ixxPsfColumn, self.iyyPsfColumn, 
-                                     self.ixyColumn, 
+                                     shearConvention=self.shearConvention)
+        self.e2ResidsFunc = E2Resids(self.ixxColumn, self.iyyColumn,
+                                     self.ixxPsfColumn, self.iyyPsfColumn,
+                                     self.ixyColumn,
                                      self.ixyPsfColumn,
-                                     shearConvention=self.shearConvention 
-        )
-        self.traceSizeFunc = TraceSize(self.ixxColumn,self.iyyColumn)
-        self.psfTraceSizeFunc = TraceSize(self.ixxPsfColumn,self.iyyPsfColumn)
+                                     shearConvention=self.shearConvention)
+        self.traceSizeFunc = TraceSize(self.ixxColumn, self.iyyColumn)
+        self.psfTraceSizeFunc = TraceSize(self.ixxPsfColumn, self.iyyPsfColumn)
         self.kwargs = kwargs
 
     def __call__(self, catalog):
@@ -487,17 +485,39 @@ def corrSpin2(
     return xy
 
 
-def calculateTEx(catalog, config):
-    """Compute ellipticity residual correlation metrics using parquet table as input. New column names based on these
-    yaml specifications  https://github.com/lsst/obs_lsst/blob/073901ab35efe5253ca64aeb14a290692ae400bd/policy/imsim/Source.yaml#L208-L226.
+def calculateTEx(catalog, config, prependString):
+    """Compute ellipticity residual correlation metrics using parquet table as
+    input. New column names based on these yaml specifications:
+    https://github.com/lsst/obs_lsst/blob/073901ab35efe5253ca64aeb14a290692ae400bd/policy/imsim/Source.yaml#L208-L226.
     """
+
+    if prependString is not None:
+        ixxColumn = prependString + "_" + config.ixxColumn
+        iyyColumn = prependString + "_" + config.iyyColumn
+        ixyColumn = prependString + "_" + config.ixyColumn
+        ixxPsfColumn = prependString + "_" + config.ixxPsfColumn
+        iyyPsfColumn = prependString + "_" + config.iyyPsfColumn
+        ixyPsfColumn = prependString + "_" + config.ixyPsfColumn
+        extendednessColumn = prependString + "_" + config.extendednessColumn
+        psfFluxColumn = prependString + "_" + config.psfFluxColumn
+        psfFluxErrColumn = prependString + "_" + config.psfFluxErrColumn
+    else:
+        ixxColumn = config.ixxColumn
+        iyyColumn = config.iyyColumn
+        ixyColumn = config.ixyColumn
+        ixxPsfColumn = config.ixxPsfColumn
+        iyyPsfColumn = config.iyyPsfColumn
+        ixyPsfColumn = config.ixyPsfColumn
+        extendednessColumn = config.extendednessColumn
+        psfFluxColumn = config.psfFluxColumn
+        psfFluxErrColumn = config.psfFluxErrColumn
 
     # TO-DO: Filtering should be pulled out into a separate function for standard quality selections
     snrMin = 50
     selection = (
-        (catalog[config.extendednessColumn] < 0.5)
+        (catalog[extendednessColumn] < 0.5)
         & (
-            (catalog[config.psfFluxColumn] / catalog[config.psfFluxErrColumn])
+            (catalog[psfFluxColumn] / catalog[psfFluxErrColumn])
             > snrMin
         )
         & (catalog[config.deblend_nChildColumn] == 0)
@@ -513,13 +533,13 @@ def calculateTEx(catalog, config):
         max_sep=config.maxSep,
         sep_units="arcmin",
     )
-    
-    rhoStatisticsFunc = RhoStatistics(config.ixxColumn, config.iyyColumn, 
-                                      config.ixxPsfColumn, config.iyyPsfColumn,
+
+    rhoStatisticsFunc = RhoStatistics(ixxColumn, iyyColumn,
+                                      ixxPsfColumn, iyyPsfColumn,
                                       config.raColumn, config.decColumn,
-                                      config.ixyColumn, 
-                                      config.ixyPsfColumn,
-                                      shearConvention=config.shearConvention, 
+                                      ixyColumn,
+                                      ixyPsfColumn,
+                                      shearConvention=config.shearConvention,
                                       **treecorrKwargs
     )
     xy = rhoStatisticsFunc(catalog[selection])[config.rhoStat]

--- a/python/lsst/faro/utils/tex_table.py
+++ b/python/lsst/faro/utils/tex_table.py
@@ -22,7 +22,6 @@
 import astropy.units as u
 import numpy as np
 import treecorr
-from typing import List
 
 
 __all__ = (
@@ -49,9 +48,7 @@ class TraceSize(object):
         self.iyyColumn = iyyColumn
 
     def __call__(self, catalog):
-        srcSize = np.sqrt(
-            0.5 * (catalog[self.ixxColumn] + catalog[self.iyyColumn])
-        )
+        srcSize = np.sqrt(0.5 * (catalog[self.ixxColumn] + catalog[self.iyyColumn]))
         return np.array(srcSize)
 
 
@@ -97,8 +94,9 @@ class E1(object):
         A numpy array of e1 ellipticity values.
     """
 
-    def __init__(self, ixxColumn, iyyColumn,
-                 ixyColumn, unitScale=1.0, shearConvention=False):
+    def __init__(
+        self, ixxColumn, iyyColumn, ixyColumn, unitScale=1.0, shearConvention=False
+    ):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
         self.ixyColumn = ixyColumn
@@ -137,8 +135,9 @@ class E2(object):
         A numpy array of e2 ellipticity values.
     """
 
-    def __init__(self, ixxColumn,
-                 iyyColumn, ixyColumn, unitScale=1.0, shearConvention=False):
+    def __init__(
+        self, ixxColumn, iyyColumn, ixyColumn, unitScale=1.0, shearConvention=False
+    ):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
         self.ixyColumn = ixyColumn
@@ -185,9 +184,17 @@ class E1Resids(object):
         A numpy array of e1 residual ellipticity values.
     """
 
-    def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn,
-                 ixyColumn, ixyPsfColumn, unitScale=1.0,
-                 shearConvention=False):
+    def __init__(
+        self,
+        ixxColumn,
+        iyyColumn,
+        ixxPsfColumn,
+        iyyPsfColumn,
+        ixyColumn,
+        ixyPsfColumn,
+        unitScale=1.0,
+        shearConvention=False,
+    ):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
         self.ixyColumn = ixyColumn
@@ -199,10 +206,20 @@ class E1Resids(object):
         self.shearConvention = shearConvention
 
     def __call__(self, catalog):
-        srcE1func = E1(self.ixxColumn, self.iyyColumn, self.ixyColumn,
-                       self.unitScale, self.shearConvention)
-        psfE1func = E1(self.ixxPsfColumn, self.iyyPsfColumn, self.ixyPsfColumn,
-                       self.unitScale, self.shearConvention)
+        srcE1func = E1(
+            self.ixxColumn,
+            self.iyyColumn,
+            self.ixyColumn,
+            self.unitScale,
+            self.shearConvention,
+        )
+        psfE1func = E1(
+            self.ixxPsfColumn,
+            self.iyyPsfColumn,
+            self.ixyPsfColumn,
+            self.unitScale,
+            self.shearConvention,
+        )
 
         srcE1 = srcE1func(catalog)
         psfE1 = psfE1func(catalog)
@@ -240,9 +257,17 @@ class E2Resids(object):
         A numpy array of e2 residual ellipticity values.
     """
 
-    def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn,
-                 ixyColumn, ixyPsfColumn, unitScale=1.0,
-                 shearConvention=False):
+    def __init__(
+        self,
+        ixxColumn,
+        iyyColumn,
+        ixxPsfColumn,
+        iyyPsfColumn,
+        ixyColumn,
+        ixyPsfColumn,
+        unitScale=1.0,
+        shearConvention=False,
+    ):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
         self.ixyColumn = ixyColumn
@@ -253,10 +278,20 @@ class E2Resids(object):
         self.shearConvention = shearConvention
 
     def __call__(self, catalog):
-        srcE2func = E2(self.ixxColumn, self.iyyColumn, self.ixyColumn,
-                       self.unitScale, self.shearConvention)
-        psfE2func = E2(self.ixxPsfColumn, self.iyyPsfColumn, self.ixyPsfColumn,
-                       self.unitScale, self.shearConvention)
+        srcE2func = E2(
+            self.ixxColumn,
+            self.iyyColumn,
+            self.ixyColumn,
+            self.unitScale,
+            self.shearConvention,
+        )
+        psfE2func = E2(
+            self.ixxPsfColumn,
+            self.iyyPsfColumn,
+            self.ixyPsfColumn,
+            self.unitScale,
+            self.shearConvention,
+        )
 
         srcE2 = srcE2func(catalog)
         psfE2 = psfE2func(catalog)
@@ -294,9 +329,19 @@ class RhoStatistics(object):
         of PSF size residuals.
     """
 
-    def __init__(self, ixxColumn, iyyColumn, ixxPsfColumn, iyyPsfColumn,
-                 raColumn, decColumn, ixyColumn,
-                 ixyPsfColumn, shearConvention=False, **kwargs):
+    def __init__(
+        self,
+        ixxColumn,
+        iyyColumn,
+        ixxPsfColumn,
+        iyyPsfColumn,
+        raColumn,
+        decColumn,
+        ixyColumn,
+        ixyPsfColumn,
+        shearConvention=False,
+        **kwargs
+    ):
         self.ixxColumn = ixxColumn
         self.iyyColumn = iyyColumn
         self.ixyColumn = ixyColumn
@@ -306,22 +351,36 @@ class RhoStatistics(object):
         self.shearConvention = shearConvention
         self.raColumn = raColumn
         self.decColumn = decColumn
-        self.e1Func = E1(self.ixxPsfColumn, self.iyyPsfColumn,
-                         self.ixyPsfColumn,
-                         shearConvention=self.shearConvention)
-        self.e2Func = E2(self.ixxPsfColumn, self.iyyPsfColumn,
-                         self.ixyPsfColumn,
-                         shearConvention=self.shearConvention)
-        self.e1ResidsFunc = E1Resids(self.ixxColumn, self.iyyColumn,
-                                     self.ixxPsfColumn, self.iyyPsfColumn,
-                                     self.ixyColumn,
-                                     self.ixyPsfColumn,
-                                     shearConvention=self.shearConvention)
-        self.e2ResidsFunc = E2Resids(self.ixxColumn, self.iyyColumn,
-                                     self.ixxPsfColumn, self.iyyPsfColumn,
-                                     self.ixyColumn,
-                                     self.ixyPsfColumn,
-                                     shearConvention=self.shearConvention)
+        self.e1Func = E1(
+            self.ixxPsfColumn,
+            self.iyyPsfColumn,
+            self.ixyPsfColumn,
+            shearConvention=self.shearConvention,
+        )
+        self.e2Func = E2(
+            self.ixxPsfColumn,
+            self.iyyPsfColumn,
+            self.ixyPsfColumn,
+            shearConvention=self.shearConvention,
+        )
+        self.e1ResidsFunc = E1Resids(
+            self.ixxColumn,
+            self.iyyColumn,
+            self.ixxPsfColumn,
+            self.iyyPsfColumn,
+            self.ixyColumn,
+            self.ixyPsfColumn,
+            shearConvention=self.shearConvention,
+        )
+        self.e2ResidsFunc = E2Resids(
+            self.ixxColumn,
+            self.iyyColumn,
+            self.ixxPsfColumn,
+            self.iyyPsfColumn,
+            self.ixyColumn,
+            self.ixyPsfColumn,
+            shearConvention=self.shearConvention,
+        )
         self.traceSizeFunc = TraceSize(self.ixxColumn, self.iyyColumn)
         self.psfTraceSizeFunc = TraceSize(self.ixxPsfColumn, self.iyyPsfColumn)
         self.kwargs = kwargs
@@ -516,10 +575,7 @@ def calculateTEx(catalog, config, prependString):
     snrMin = 50
     selection = (
         (catalog[extendednessColumn] < 0.5)
-        & (
-            (catalog[psfFluxColumn] / catalog[psfFluxErrColumn])
-            > snrMin
-        )
+        & ((catalog[psfFluxColumn] / catalog[psfFluxErrColumn]) > snrMin)
         & (catalog[config.deblend_nChildColumn] == 0)
     )
 
@@ -534,13 +590,17 @@ def calculateTEx(catalog, config, prependString):
         sep_units="arcmin",
     )
 
-    rhoStatisticsFunc = RhoStatistics(ixxColumn, iyyColumn,
-                                      ixxPsfColumn, iyyPsfColumn,
-                                      config.raColumn, config.decColumn,
-                                      ixyColumn,
-                                      ixyPsfColumn,
-                                      shearConvention=config.shearConvention,
-                                      **treecorrKwargs
+    rhoStatisticsFunc = RhoStatistics(
+        ixxColumn,
+        iyyColumn,
+        ixxPsfColumn,
+        iyyPsfColumn,
+        config.raColumn,
+        config.decColumn,
+        ixyColumn,
+        ixyPsfColumn,
+        shearConvention=config.shearConvention,
+        **treecorrKwargs
     )
     xy = rhoStatisticsFunc(catalog[selection])[config.rhoStat]
 

--- a/python/lsst/faro/utils/tex_table.py
+++ b/python/lsst/faro/utils/tex_table.py
@@ -514,8 +514,6 @@ def calculateTEx(catalog, config):
         sep_units="arcmin",
     )
     
-    # TO-DO: should shearConvention be passed to rhoStatisticsFunc as a keyword arguement? It 
-    # is not in the current implementation of tex.py
     rhoStatisticsFunc = RhoStatistics(config.ixxColumn, config.iyyColumn, 
                                       config.ixxPsfColumn, config.iyyPsfColumn,
                                       config.raColumn, config.decColumn,

--- a/python/lsst/faro/utils/tex_table.py
+++ b/python/lsst/faro/utils/tex_table.py
@@ -67,7 +67,7 @@ class PsfTraceSizeDiff(object):
             0.5 * (catalog["Ixx"] + catalog["Iyy"])
         )
         psfSize = np.sqrt(
-            0.5 * (catalog["IxxPSF"] + catalog["IyyPsf"])
+            0.5 * (catalog["IxxPsf"] + catalog["IyyPsf"])
         )
         sizeDiff = 100 * (srcSize - psfSize) / (0.5 * (srcSize + psfSize))
         return np.array(sizeDiff)

--- a/python/lsst/faro/utils/tex_table.py
+++ b/python/lsst/faro/utils/tex_table.py
@@ -1,0 +1,475 @@
+# This file is part of faro.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import astropy.units as u
+import numpy as np
+import treecorr
+from typing import List
+
+
+__all__ = (
+    "TraceSize",
+    "PsfTraceSizeDiff",
+    "E1",
+    "E2",
+    "E1Resids",
+    "E2Resids",
+    "RhoStatistics",
+    "corrSpin0",
+    "corrSpin2",
+    "calculateTEx",
+)
+
+
+class TraceSize(object):
+    """Functor to calculate trace radius size for sources.
+    """
+
+    def __init__(self, column):
+        self.column = column
+
+    def __call__(self, catalog):
+        srcSize = np.sqrt(
+            0.5 * (catalog["Ixx"] + catalog["Iyy"])
+        )
+        return np.array(srcSize)
+
+
+class PsfTraceSizeDiff(object):
+    """Functor to calculate trace radius size difference (%) between object and
+    PSF model.
+    """
+
+    def __init__(self, column, psfColumn):
+        self.column = column
+        self.psfColumn = psfColumn
+
+    def __call__(self, catalog):
+        srcSize = np.sqrt(
+            0.5 * (catalog["Ixx"] + catalog["Iyy"])
+        )
+        psfSize = np.sqrt(
+            0.5 * (catalog["IxxPSF"] + catalog["IyyPsf"])
+        )
+        sizeDiff = 100 * (srcSize - psfSize) / (0.5 * (srcSize + psfSize))
+        return np.array(sizeDiff)
+
+
+class E1(object):
+    """Function to calculate e1 ellipticities from a given catalog.
+    Parameters
+    ----------
+    column : `str`
+        The name of the shape measurement algorithm. It should be one of
+        ("base_SdssShape", "ext_shapeHSM_HsmSourceMoments") or
+        ("base_SdssShape_psf", "ext_shapeHSM_HsmPsfMoments") for corresponding
+        PSF ellipticities.
+    unitScale : `float`, optional
+        A numerical scaling factor to multiply the ellipticity.
+    shearConvention: `bool`, optional
+        Option to use shear convention. When set to False, the distortion
+        convention is used.
+    Returns
+    -------
+    e1 : `numpy.array`
+        A numpy array of e1 ellipticity values.
+    """
+
+    def __init__(self, column, unitScale=1.0, shearConvention=False):
+        self.column = column
+        self.unitScale = unitScale
+        self.shearConvention = shearConvention
+
+    def __call__(self, catalog):
+        xx = catalog["Ixx"]
+        yy = catalog["Iyy"]
+        if self.shearConvention:
+            xy = catalog["Ixy"]
+            e1 = (xx - yy) / (xx + yy + 2.0 * np.sqrt(xx * yy - xy ** 2))
+        else:
+            e1 = (xx - yy) / (xx + yy)
+        return np.array(e1) * self.unitScale
+
+
+class E2(object):
+    """Function to calculate e2 ellipticities from a given catalog.
+    Parameters
+    ----------
+    column : `str`
+        The name of the shape measurement algorithm. It should be ixx for both
+        "base_SdssShape" and ext_shapeHSM_HsmSource"
+    unitScale : `float`, optional
+        A numerical scaling factor to multiply the ellipticity.
+    shearConvention: `bool`, optional
+        Option to use shear convention. When set to False, the distortion
+        convention is used.
+    Returns
+    -------
+    e2 : `numpy.array`
+        A numpy array of e2 ellipticity values.
+    """
+
+    def __init__(self, column, unitScale=1.0, shearConvention=False):
+        self.column = column
+        self.unitScale = unitScale
+        self.shearConvention = shearConvention
+
+    def __call__(self, catalog):
+        xx = catalog["Ixx"]
+        yy = catalog["Iyy"]
+        xy = catalog["Ixy"]
+        if self.shearConvention:
+            e2 = (2.0 * xy) / (xx + yy + 2.0 * np.sqrt(xx * yy - xy ** 2))
+        else:
+            e2 = (2.0 * xy) / (xx + yy)
+        return np.array(e2) * self.unitScale
+
+
+class E1Resids(object):
+    """Functor to calculate e1 ellipticity residuals from an object catalog
+    and PSF model.
+    Parameters
+    ----------
+    column : `str`
+        The name of the shape measurement algorithm. It should be one of
+        ("base_SdssShape", "ext_shapeHSM_HsmSourceMoments").
+    psfColumn : `str`
+        The name used for PSF shape measurements from the same algorithm.
+        It must be one of ("base_SdssShape_psf", "ext_shapeHSM_HsmPsfMoments")
+        and correspond to the algorithm name specified for ``column``.
+    unitScale : `float`, optional
+        A numerical scaling factor to multiply both the object and PSF
+        ellipticities.
+    shearConvention: `bool`, optional
+        Option to use shear convention. When set to False, the distortion
+        convention is used.
+    Returns
+    -------
+    e1Resids : `numpy.array`
+        A numpy array of e1 residual ellipticity values.
+    """
+
+    def __init__(self, column, psfColumn, unitScale=1.0, shearConvention=False):
+        self.column = column
+        self.psfColumn = psfColumn
+        self.unitScale = unitScale
+        self.shearConvention = shearConvention
+
+    def __call__(self, catalog):
+        srcE1func = E1(self.column, self.unitScale, self.shearConvention)
+        psfE1func = E1(self.psfColumn, self.unitScale, self.shearConvention)
+
+        srcE1 = srcE1func(catalog)
+        psfE1 = psfE1func(catalog)
+
+        e1Resids = srcE1 - psfE1
+        return e1Resids
+
+
+class E2Resids(object):
+    """Functor to calculate e2 ellipticity residuals from an object catalog
+    and PSF model.
+    Parameters
+    ----------
+    column : `str`
+        The name of the shape measurement algorithm. It should be one of
+        ("base_SdssShape", "ext_shapeHSM_HsmSourceMoments").
+    psfColumn : `str`
+        The name used for PSF shape measurements from the same algorithm.
+        It must be one of ("base_SdssShape_psf", "ext_shapeHSM_HsmPsfMoments")
+        and correspond to the algorithm name specified for ``column``.
+    unitScale : `float`, optional
+        A numerical scaling factor to multiply both the object and PSF
+        ellipticities.
+    shearConvention: `bool`, optional
+        Option to use shear convention. When set to False, the distortion
+        convention is used.
+    Returns
+    -------
+    e2Resids : `numpy.array`
+        A numpy array of e2 residual ellipticity values.
+    """
+
+    def __init__(self, column, psfColumn, unitScale=1.0, shearConvention=False):
+        self.column = column
+        self.psfColumn = psfColumn
+        self.unitScale = unitScale
+        self.shearConvention = shearConvention
+
+    def __call__(self, catalog):
+        srcE2func = E2(self.column, self.unitScale, self.shearConvention)
+        psfE2func = E2(self.psfColumn, self.unitScale, self.shearConvention)
+
+        srcE2 = srcE2func(catalog)
+        psfE2 = psfE2func(catalog)
+
+        e2Resids = srcE2 - psfE2
+        return e2Resids
+
+
+class RhoStatistics(object):
+    """Functor to compute Rho statistics given star catalog and PSF model.
+    For detailed description of Rho statistics, refer to
+    Rowe (2010) and Jarvis et al., (2016).
+    Parameters
+    ----------
+    column : `str`
+        The name of the shape measurement algorithm. It should be one of
+        ("base_SdssShape", "ext_shapeHSM_HsmSourceMoments").
+    psfColumn : `str`
+        The name used for PSF shape measurements from the same algorithm.
+        It must be one of ("base_SdssShape_psf", "ext_shapeHSM_HsmPsfMoments")
+        and correspond to the algorithm name specified for ``column``.
+    shearConvention: `bool`, optional
+        Option to use shear convention. When set to False, the distortion
+        convention is used.
+    **kwargs
+        Additional keyword arguments passed to treecorr. See
+        https://rmjarvis.github.io/TreeCorr/_build/html/gg.html for details.
+    Returns
+    -------
+    rhoStats : `dict` [`int`, `treecorr.KKCorrelation` or
+                              `treecorr.GGCorrelation`]
+        A dictionary with keys 0..5, containing one `treecorr.KKCorrelation`
+        object (key 0) and five `treecorr.GGCorrelation` objects corresponding
+        to Rho statistic indices. rho0 corresponds to autocorrelation function
+        of PSF size residuals.
+    """
+
+    def __init__(self, column, psfColumn, shearConvention=False, **kwargs):
+        self.column = column
+        self.psfColumn = psfColumn
+        self.shearConvention = shearConvention
+        self.e1Func = E1(self.psfColumn, shearConvention=self.shearConvention)
+        self.e2Func = E2(self.psfColumn, shearConvention=self.shearConvention)
+        self.e1ResidsFunc = E1Resids(
+            self.column, self.psfColumn, shearConvention=self.shearConvention
+        )
+        self.e2ResidsFunc = E2Resids(
+            self.column, self.psfColumn, shearConvention=self.shearConvention
+        )
+        self.traceSizeFunc = TraceSize(self.column)
+        self.psfTraceSizeFunc = TraceSize(self.psfColumn)
+        self.kwargs = kwargs
+
+    def __call__(self, catalog):
+        e1 = self.e1Func(catalog)
+        e2 = self.e2Func(catalog)
+        e1Res = self.e1ResidsFunc(catalog)
+        e2Res = self.e2ResidsFunc(catalog)
+        traceSize2 = self.traceSizeFunc(catalog) ** 2
+        psfTraceSize2 = self.psfTraceSizeFunc(catalog) ** 2
+        SizeRes = (traceSize2 - psfTraceSize2) / (0.5 * (traceSize2 + psfTraceSize2))
+
+        isFinite = np.isfinite(e1Res) & np.isfinite(e2Res) & np.isfinite(SizeRes)
+        e1 = e1[isFinite]
+        e2 = e2[isFinite]
+        e1Res = e1Res[isFinite]
+        e2Res = e2Res[isFinite]
+        SizeRes = SizeRes[isFinite]
+
+        # Scale the SizeRes by ellipticities
+        e1SizeRes = e1 * SizeRes
+        e2SizeRes = e2 * SizeRes
+
+        # Package the arguments to capture auto-/cross-correlations for the
+        # Rho statistics.
+        args = {
+            0: (SizeRes, None),
+            1: (e1Res, e2Res, None, None),
+            2: (e1, e2, e1Res, e2Res),
+            3: (e1SizeRes, e2SizeRes, None, None),
+            4: (e1Res, e2Res, e1SizeRes, e2SizeRes),
+            5: (e1, e2, e1SizeRes, e2SizeRes),
+        }
+
+        ra = np.rad2deg(catalog["coord_ra"][isFinite]) * 60.0  # arcmin
+        dec = np.rad2deg(catalog["coord_dec"][isFinite]) * 60.0  # arcmin
+
+        # Pass the appropriate arguments to the correlator and build a dict
+        rhoStats = {
+            rhoIndex: corrSpin2(
+                ra,
+                dec,
+                *(args[rhoIndex]),
+                raUnits="arcmin",
+                decUnits="arcmin",
+                **self.kwargs
+            )
+            for rhoIndex in range(1, 6)
+        }
+        rhoStats[0] = corrSpin0(
+            ra, dec, *(args[0]), raUnits="arcmin", decUnits="arcmin", **self.kwargs
+        )
+
+        return rhoStats
+
+
+def corrSpin0(
+    ra, dec, k1, k2=None, raUnits="degrees", decUnits="degrees", **treecorrKwargs
+):
+    """Function to compute correlations between at most two scalar fields.
+    This is used to compute Rho0 statistics, given the appropriate spin-0
+    (scalar) fields, usually fractional size residuals.
+    Parameters
+    ----------
+    ra : `numpy.array`
+        The right ascension values of entries in the catalog.
+    dec : `numpy.array`
+        The declination values of entries in the catalog.
+    k1 : `numpy.array`
+        The primary scalar field.
+    k2 : `numpy.array`, optional
+        The secondary scalar field.
+        Autocorrelation of the primary field is computed if `None` (default).
+    raUnits : `str`, optional
+        Unit of the right ascension values.
+        Valid options are "degrees", "arcmin", "arcsec", "hours" or "radians".
+    decUnits : `str`, optional
+        Unit of the declination values.
+        Valid options are "degrees", "arcmin", "arcsec", "hours" or "radians".
+    **treecorrKwargs
+        Keyword arguments to be passed to `treecorr.KKCorrelation`.
+    Returns
+    -------
+    xy : `treecorr.KKCorrelation`
+        A `treecorr.KKCorrelation` object containing the correlation function.
+    """
+
+    xy = treecorr.KKCorrelation(**treecorrKwargs)
+    catA = treecorr.Catalog(ra=ra, dec=dec, k=k1, ra_units=raUnits, dec_units=decUnits)
+    if k2 is None:
+        # Calculate the auto-correlation
+        xy.process(catA)
+    else:
+        catB = treecorr.Catalog(
+            ra=ra, dec=dec, k=k2, ra_units=raUnits, dec_units=decUnits
+        )
+        # Calculate the cross-correlation
+        xy.process(catA, catB)
+
+    return xy
+
+
+def corrSpin2(
+    ra,
+    dec,
+    g1a,
+    g2a,
+    g1b=None,
+    g2b=None,
+    raUnits="degrees",
+    decUnits="degrees",
+    **treecorrKwargs
+):
+    """Function to compute correlations between at most two shear-like fields.
+    This is used to compute Rho statistics, given the appropriate spin-2
+    (shear-like) fields.
+    Parameters
+    ----------
+    ra : `numpy.array`
+        The right ascension values of entries in the catalog.
+    dec : `numpy.array`
+        The declination values of entries in the catalog.
+    g1a : `numpy.array`
+        The first component of the primary shear-like field.
+    g2a : `numpy.array`
+        The second component of the primary shear-like field.
+    g1b : `numpy.array`, optional
+        The first component of the secondary shear-like field.
+        Autocorrelation of the primary field is computed if `None` (default).
+    g2b : `numpy.array`, optional
+        The second component of the secondary shear-like field.
+        Autocorrelation of the primary field is computed if `None` (default).
+    raUnits : `str`, optional
+        Unit of the right ascension values.
+        Valid options are "degrees", "arcmin", "arcsec", "hours" or "radians".
+    decUnits : `str`, optional
+        Unit of the declination values.
+        Valid options are "degrees", "arcmin", "arcsec", "hours" or "radians".
+    **treecorrKwargs
+        Keyword arguments to be passed to `treecorr.GGCorrelation`.
+    Returns
+    -------
+    xy : `treecorr.GGCorrelation`
+        A `treecorr.GGCorrelation` object containing the correlation function.
+    """
+    xy = treecorr.GGCorrelation(**treecorrKwargs)
+    catA = treecorr.Catalog(
+        ra=ra, dec=dec, g1=g1a, g2=g2a, ra_units=raUnits, dec_units=decUnits
+    )
+    if g1b is None or g2b is None:
+        # Calculate the auto-correlation
+        xy.process(catA)
+    else:
+        catB = treecorr.Catalog(
+            ra=ra, dec=dec, g1=g1b, g2=g2b, ra_units=raUnits, dec_units=decUnits
+        )
+        # Calculate the cross-correlation
+        xy.process(catA, catB)
+
+    return xy
+
+
+def calculateTEx(catalog, config):
+    """Compute ellipticity residual correlation metrics using parquet table as input. New column names based on these
+    yaml specifications  https://github.com/lsst/obs_lsst/blob/073901ab35efe5253ca64aeb14a290692ae400bd/policy/imsim/Source.yaml#L208-L226
+    """
+
+    # Filtering should be pulled out into a separate function for standard quality selections
+
+    # TO-DO: update column names following https://github.com/yalsayyad/dm_notebooks/blob/master/object-table/ci_imsim_check_for_DRP_Table_and_Column.ipynb
+
+    snrMin = 50
+    selection = (
+        (catalog["extendedness"] < 0.5)
+        & (
+            (catalog["PsFlux"] / catalog["PsFluxErr"])
+            > snrMin
+        )
+        & (catalog["Deblend_nChild"] == 0)
+    )
+
+    nMinSources = 50
+    if np.sum(selection) < nMinSources:
+        return {"nomeas": np.nan * u.Unit("")}
+
+    treecorrKwargs = dict(
+        nbins=config.nbins,
+        min_sep=config.minSep,
+        max_sep=config.maxSep,
+        sep_units="arcmin",
+    )
+    rhoStatistics = RhoStatistics(
+        config.column, config.columnPsf, config.shearConvention, **treecorrKwargs
+    )
+    xy = rhoStatistics(catalog[selection])[config.rhoStat]
+
+    radius = np.exp(xy.meanlogr) * u.arcmin
+    if config.rhoStat == 0:
+        corr = xy.xi * u.Unit("")
+        corrErr = np.sqrt(xy.varxip) * u.Unit("")
+    else:
+        corr = xy.xip * u.Unit("")
+        corrErr = np.sqrt(xy.varxip) * u.Unit("")
+
+    result = dict(radius=radius, corr=corr, corrErr=corrErr)
+    return result

--- a/python/lsst/faro/utils/tex_table.py
+++ b/python/lsst/faro/utils/tex_table.py
@@ -545,9 +545,20 @@ def corrSpin2(
 
 
 def calculateTEx(catalog, config, prependString):
-    """Compute ellipticity residual correlation metrics using parquet table as
-    input. New column names based on these yaml specifications:
-    https://github.com/lsst/obs_lsst/blob/073901ab35efe5253ca64aeb14a290692ae400bd/policy/imsim/Source.yaml#L208-L226.
+    """Compute ellipticity residual correlation metrics using parquet table as input.
+    Parameters
+    ----------
+    catalog : `pandas datafram`
+        The catalog on which TE values will be calculated.
+    config : `pex config`
+        Task configuration.
+    prependString : `str`
+        The string to prepend to the band-specific columns. Typically a single letter
+        filter e.g. 'g'.
+    Returns
+    -------
+    result : `dict`
+        A dictionary with entries for radius, corr, and corrErr.
     """
 
     if prependString is not None:

--- a/tests/data/TE1_expected_0_i.yaml
+++ b/tests/data/TE1_expected_0_i.yaml
@@ -8,4 +8,4 @@ identifier: cb5f325dc52f4ef794b3165b406c6fa4
 metric: TE1
 notes: {}
 unit: ''
-value: 9.517637187446586e-05
+value: 0.0005146044101963828


### PR DESCRIPTION
Jenkins job -> https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/35491/pipeline

This also resulted in a few minor changes to tex.py and some of its dependencies, see notes in JIRA ticket (https://jira.lsstcorp.org/browse/DM-32229)