### PR TITLE
DM-26987: Update filtering of matched catalog to operate before creating GroupView

### DIFF
--- a/pipelines/measurement/measurement_matched.yaml
+++ b/pipelines/measurement/measurement_matched.yaml
@@ -23,6 +23,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: AM1
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractMag17to21p5'
         from lsst.faro.measurement import AMxTask
         config.measure.retarget(AMxTask)
         config.measure.annulus_r = 5.0
@@ -32,6 +33,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: AM2
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractMag17to21p5'
         from lsst.faro.measurement import AMxTask
         config.measure.retarget(AMxTask)
         config.measure.annulus_r = 20.0
@@ -41,6 +43,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: AM3
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractMag17to21p5'
         from lsst.faro.measurement import AMxTask
         config.measure.retarget(AMxTask)
         config.measure.annulus_r = 200.0
@@ -50,6 +53,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: AD1_design
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractMag17to21p5'
         from lsst.faro.measurement import ADxTask
         config.measure.retarget(ADxTask)
         config.measure.annulus_r = 5.0
@@ -61,6 +65,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: AD2_design
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractMag17to21p5'
         from lsst.faro.measurement import ADxTask
         config.measure.retarget(ADxTask)
         config.measure.annulus_r = 20.0
@@ -72,6 +77,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: AD3_design
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractMag17to21p5'
         from lsst.faro.measurement import ADxTask
         config.measure.retarget(ADxTask)
         config.measure.annulus_r = 200.0
@@ -83,6 +89,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: AF1_design
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractMag17to21p5'
         from lsst.faro.measurement import AFxTask
         config.measure.retarget(AFxTask)
         config.measure.annulus_r = 5.0
@@ -94,6 +101,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: AF2_design
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractMag17to21p5'
         from lsst.faro.measurement import AFxTask
         config.measure.retarget(AFxTask)
         config.measure.annulus_r = 20.0
@@ -105,6 +113,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: AF3_design
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractMag17to21p5'
         from lsst.faro.measurement import AFxTask
         config.measure.retarget(AFxTask)
         config.measure.annulus_r = 200.0
@@ -116,6 +125,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: modelPhotRepGal1
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractGxsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 1
@@ -128,6 +138,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: modelPhotRepGal2
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractGxsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 2
@@ -140,6 +151,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: modelPhotRepGal3
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractGxsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 3
@@ -152,6 +164,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: modelPhotRepGal4
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractGxsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 4
@@ -164,6 +177,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: modelPhotRepStar1
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractStarsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 1
@@ -176,6 +190,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: modelPhotRepStar2
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractStarsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 2
@@ -188,6 +203,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: modelPhotRepStar3
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractStarsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 3
@@ -200,6 +216,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: modelPhotRepStar4
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractStarsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 4
@@ -212,6 +229,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: psfPhotRepStar1
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractStarsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 1
@@ -225,6 +243,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: psfPhotRepStar2
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractStarsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 2
@@ -238,6 +257,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: psfPhotRepStar3
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractStarsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 3
@@ -251,6 +271,7 @@ tasks:
       connections.package: validate_drp
       connections.metric: psfPhotRepStar4
       python: |
+        config.connections.matchedCatalog = 'matchedCatalogTractStarsSNR5to80'
         from lsst.faro.measurement import ModelPhotRepTask
         config.measure.retarget(ModelPhotRepTask)
         config.measure.index = 4

--- a/pipelines/measurement/measurement_matched_multi.yaml
+++ b/pipelines/measurement/measurement_matched_multi.yaml
@@ -6,5 +6,6 @@ tasks:
       connections.package: validate_drp
       connections.metric: AB1
       python: |
+        config.connections.matchedCatalogMulti = 'matchedCatalogPatchMultiBand'
         from lsst.faro.measurement.MatchedCatalogMeasurementTasks import AB1Task
         config.measure.retarget(AB1Task)

--- a/pipelines/preparation/preparation_matched.yaml
+++ b/pipelines/preparation/preparation_matched.yaml
@@ -4,3 +4,33 @@ tasks:
     class: lsst.faro.preparation.PatchMatchedPreparationTask
   matchCatalogsTract:
     class: lsst.faro.preparation.TractMatchedPreparationTask
+  matchCatalogsTractMag17to21p5:
+    # Used by astrometric repeatability metrics
+    class: lsst.faro.preparation.TractMatchedPreparationTask
+    config:
+      snrMin: 10
+      snrMax: 50000
+      brightMagCut: 17.0
+      faintMagCut: 21.5
+      selectExtended: False
+      python: |
+        config.connections.outputCatalog = 'matchedCatalogTractMag17to21p5'
+  matchCatalogsTractStarsSNR5to80:
+    # Used by "photRepStar" stellar photometric repeatability metrics
+    class: lsst.faro.preparation.TractMatchedPreparationTask
+    config:
+      snrMin: 5
+      snrMax: 80
+      selectExtended: False
+      python: |
+        config.connections.outputCatalog = 'matchedCatalogTractStarsSNR5to80'
+  matchCatalogsTractGxsSNR5to80:
+    # Used by "photRepGal" galaxy photometric repeatability metrics
+    class: lsst.faro.preparation.TractMatchedPreparationTask
+    config:
+      snrMin: 5
+      snrMax: 80
+      selectExtended: True
+      python: |
+        config.connections.outputCatalog = 'matchedCatalogTractGxsSNR5to80'
+

--- a/pipelines/preparation/preparation_matched_jointcal_fgcm.yaml
+++ b/pipelines/preparation/preparation_matched_jointcal_fgcm.yaml
@@ -8,6 +8,47 @@ tasks:
         config.useGlobalExternalPhotoCalib = True
         config.doApplyExternalSkyWcs = True
         config.useGlobalExternalSkyWcs = False
+  matchCatalogsTractMag17to21p5:
+    # Used by astrometric repeatability metrics
+    class: lsst.faro.preparation.TractMatchedPreparationTask
+    config:
+      snrMin: 10
+      snrMax: 50000
+      brightMagCut: 17.0
+      faintMagCut: 21.5
+      selectExtended: False
+      python: |
+        config.connections.outputCatalog = 'matchedCatalogTractMag17to21p5'
+        config.doApplyExternalPhotoCalib = True
+        config.useGlobalExternalPhotoCalib = True
+        config.doApplyExternalSkyWcs = True
+        config.useGlobalExternalSkyWcs = False
+  matchCatalogsTractStarsSNR5to80:
+    # Used by "photRepStar" stellar photometric repeatability metrics
+    class: lsst.faro.preparation.TractMatchedPreparationTask
+    config:
+      snrMin: 5
+      snrMax: 80
+      selectExtended: False
+      python: |
+        config.connections.outputCatalog = 'matchedCatalogTractStarsSNR5to80'
+        config.doApplyExternalPhotoCalib = True
+        config.useGlobalExternalPhotoCalib = True
+        config.doApplyExternalSkyWcs = True
+        config.useGlobalExternalSkyWcs = False
+  matchCatalogsTractGxsSNR5to80:
+    # Used by "photRepGal" galaxy photometric repeatability metrics
+    class: lsst.faro.preparation.TractMatchedPreparationTask
+    config:
+      snrMin: 5
+      snrMax: 80
+      selectExtended: True
+      python: |
+        config.connections.outputCatalog = 'matchedCatalogTractGxsSNR5to80'
+        config.doApplyExternalPhotoCalib = True
+        config.useGlobalExternalPhotoCalib = True
+        config.doApplyExternalSkyWcs = True
+        config.useGlobalExternalSkyWcs = False
   matchCatalogsPatch:
     class: lsst.faro.preparation.PatchMatchedPreparationTask
     config:

--- a/pipelines/preparation/preparation_matched_multi.yaml
+++ b/pipelines/preparation/preparation_matched_multi.yaml
@@ -1,4 +1,17 @@
 description: Produce multiband matched catalogs
 tasks:
   matchCatalogsPatchMultiBand:
+    # Used by astrometric repeatability metrics
     class: lsst.faro.preparation.PatchMatchedMultiBandPreparationTask
+    config:
+      snrMin: 10
+      snrMax: 50000
+      brightMagCut: 17.0
+      faintMagCut: 21.5
+      selectExtended: False
+      python: |
+        config.connections.outputCatalog = 'matchedCatalogPatchMultiBand'
+        config.doApplyExternalPhotoCalib = False
+        config.useGlobalExternalPhotoCalib = False
+        config.doApplyExternalSkyWcs = False
+        config.useGlobalExternalSkyWcs = False

--- a/pipelines/preparation/preparation_matched_multi_jointcal_fgcm.yaml
+++ b/pipelines/preparation/preparation_matched_multi_jointcal_fgcm.yaml
@@ -10,7 +10,6 @@ tasks:
       faintMagCut: 21.5
       selectExtended: False
       python: |
-        config.connections.outputCatalog = 'matchedCatalogPatchMultiBand'
         config.doApplyExternalPhotoCalib = True
         config.useGlobalExternalPhotoCalib = True
         config.doApplyExternalSkyWcs = True

--- a/pipelines/preparation/preparation_matched_multi_jointcal_fgcm.yaml
+++ b/pipelines/preparation/preparation_matched_multi_jointcal_fgcm.yaml
@@ -1,9 +1,17 @@
 description: Produce multiband matched catalogs
 tasks:
   matchCatalogsPatchMultiBand:
+    # Used by astrometric repeatability metrics
     class: lsst.faro.preparation.PatchMatchedMultiBandPreparationTask
     config:
+      snrMin: 10
+      snrMax: 50000
+      brightMagCut: 17.0
+      faintMagCut: 21.5
+      selectExtended: False
       python: |
+        config.connections.outputCatalog = 'matchedCatalogPatchMultiBand'
         config.doApplyExternalPhotoCalib = True
         config.useGlobalExternalPhotoCalib = True
         config.doApplyExternalSkyWcs = True
+        config.useGlobalExternalSkyWcs = False

--- a/python/lsst/faro/base/MatchedCatalogBase.py
+++ b/python/lsst/faro/base/MatchedCatalogBase.py
@@ -142,6 +142,23 @@ class MatchedBaseConfig(
     match_radius = pexConfig.Field(
         doc="Match radius in arcseconds.", dtype=float, default=1
     )
+    snrMin = pexConfig.Field(
+        doc="Minimum median SNR for a source to be included.",
+        dtype=float, default=200
+    )
+    snrMax = pexConfig.Field(
+        doc="Maximum median SNR for a source to be included.",
+        dtype=float, default=np.Inf
+    )
+    brightMagCut = pexConfig.Field(
+        doc="Bright limit of catalog entries to include.", dtype=float, default=10.0
+    )
+    faintMagCut = pexConfig.Field(
+        doc="Faint limit of catalog entries to include.", dtype=float, default=30.0
+    )
+    selectExtended = pexConfig.Field(
+        doc="Whether to select extended sources", dtype=bool, default=False
+    )
     doApplyExternalSkyWcs = pexConfig.Field(
         doc="Whether or not to use the external wcs.", dtype=bool, default=False
     )
@@ -186,7 +203,8 @@ class MatchedBaseTask(pipeBase.PipelineTask):
             out_matched = afwTable.SimpleCatalog()
         else:
             srcvis, matched = matchCatalogs(
-                sourceCatalogs, photoCalibs, astromCalibs, dataIds, radius, logger=self.log
+                sourceCatalogs, photoCalibs, astromCalibs, dataIds, radius,
+                self.config, logger=self.log
             )
             # Trim the output to the patch bounding box
             out_matched = type(matched)(matched.schema)

--- a/python/lsst/faro/base/MatchedCatalogBase.py
+++ b/python/lsst/faro/base/MatchedCatalogBase.py
@@ -143,11 +143,11 @@ class MatchedBaseConfig(
         doc="Match radius in arcseconds.", dtype=float, default=1
     )
     snrMin = pexConfig.Field(
-        doc="Minimum median SNR for a source to be included.",
+        doc="Minimum SNR for a source to be included.",
         dtype=float, default=200
     )
     snrMax = pexConfig.Field(
-        doc="Maximum median SNR for a source to be included.",
+        doc="Maximum SNR for a source to be included.",
         dtype=float, default=np.Inf
     )
     brightMagCut = pexConfig.Field(

--- a/python/lsst/faro/measurement/MatchedCatalogMeasurementTasks.py
+++ b/python/lsst/faro/measurement/MatchedCatalogMeasurementTasks.py
@@ -130,6 +130,7 @@ class PA1Task(Task):
             nMinPhotRepeat=self.config.nMinPhotRepeat,
             snrMax=self.config.brightSnrMax,
             snrMin=self.config.brightSnrMin,
+            doFlags=False, isPrimary=False,
         )
 
         if "magMean" in pa1.keys():
@@ -224,6 +225,7 @@ class PF1Task(Task):
             nMinPhotRepeat=self.config.nMinPhotRepeat,
             snrMax=self.config.brightSnrMax,
             snrMin=self.config.brightSnrMin,
+            doFlags=False, isPrimary=False,
         )
 
         if "magResid" in pf1.keys():
@@ -527,6 +529,7 @@ class ModelPhotRepTask(Task):
             snrMin=self.config.selectSnrMin,
             magName=self.config.magName,
             extended=self.config.selectExtended,
+            doFlags=False, isPrimary=False,
         )
 
         name_type = "Gal" if self.config.selectExtended else "Star"

--- a/python/lsst/faro/utils/matcher.py
+++ b/python/lsst/faro/utils/matcher.py
@@ -163,8 +163,6 @@ def matchCatalogs(
         srcVis.extend(tmpCat, False)
         mmatch.add(catalog=tmpCat, dataId=dataId)
 
-    # import pdb; pdb.set_trace()
-
     # Complete the match, returning a catalog that includes
     # all matched sources with object IDs that can be used to group them.
     matchCat = mmatch.finish()

--- a/python/lsst/faro/utils/matcher.py
+++ b/python/lsst/faro/utils/matcher.py
@@ -30,6 +30,7 @@ from lsst.afw.table import (
     updateSourceCoords,
 )
 from lsst.faro.utils.calibrated_catalog import CalibratedCatalog
+from lsst.faro.utils.prefilter import preFilter
 
 import numpy as np
 from astropy.table import join, Table
@@ -50,6 +51,7 @@ def matchCatalogs(
         astromCalibs: List[SkyWcs],
         dataIds,
         matchRadius: float,
+        config,
         logger=None,
 ):
     schema = inputs[0].schema
@@ -154,8 +156,14 @@ def matchCatalogs(
         tmpCat["psf_e1"][:] = psf_e1
         tmpCat["psf_e2"][:] = psf_e2
 
+        tmpCat = preFilter(tmpCat, snrMin=config.snrMin, snrMax=config.snrMax,
+                           brightMagCut=config.brightMagCut, faintMagCut=config.faintMagCut,
+                           extended=config.selectExtended)
+
         srcVis.extend(tmpCat, False)
         mmatch.add(catalog=tmpCat, dataId=dataId)
+
+    # import pdb; pdb.set_trace()
 
     # Complete the match, returning a catalog that includes
     # all matched sources with object IDs that can be used to group them.

--- a/python/lsst/faro/utils/prefilter.py
+++ b/python/lsst/faro/utils/prefilter.py
@@ -76,7 +76,7 @@ def preFilter(
         return is_primary
 
     allfilt = filtSNR(sourceCatalog) & filtExtended(sourceCatalog) &\
-              filtFlags(sourceCatalog) & filtPrimary(sourceCatalog) &\
-              filtMag(sourceCatalog)
+        filtFlags(sourceCatalog) & filtPrimary(sourceCatalog) &\
+        filtMag(sourceCatalog)
 
     return sourceCatalog[allfilt].copy(deep=True)

--- a/python/lsst/faro/utils/prefilter.py
+++ b/python/lsst/faro/utils/prefilter.py
@@ -1,0 +1,83 @@
+# This file is part of faro.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+from lsst.afw.table import GroupView
+
+__all__ = ("preFilter",)
+
+
+def preFilter(
+    sourceCatalog,
+    snrMin=None,
+    snrMax=None,
+    brightMagCut=None,
+    faintMagCut=None,
+    extended=None,
+    doFlags=None,
+    isPrimary=None,
+    psfStars=None,
+    photoCalibStars=None,
+    astromCalibStars=None,
+):
+
+    if snrMin is None:
+        snrMin = 50.0
+    if snrMax is None:
+        snrMax = np.Inf
+    if extended is None:
+        extended = False
+
+    def filtSNR(cat):
+        oksnr = (cat["base_PsfFlux_snr"] > snrMin) & (cat["base_PsfFlux_snr"] < snrMax)
+        return oksnr
+
+    def filtMag(cat):
+        if (brightMagCut is not None) and (faintMagCut is not None):
+            okmag = (cat["base_PsfFlux_mag"] > brightMagCut) & (cat["base_PsfFlux_mag"] < faintMagCut)
+        else:
+            okmag = (cat["base_PsfFlux_mag"] < 30.0)
+        return okmag
+
+    def filtExtended(cat):
+        if extended:
+            sourceType = (cat["base_ClassificationExtendedness_value"] > 0.9)
+        else:
+            sourceType = (cat["base_ClassificationExtendedness_value"] < 0.1)
+        return sourceType
+
+    def filtFlags(cat):
+        flag_sat = ~cat["base_PixelFlags_flag_saturated"]
+        flag_cr = ~cat["base_PixelFlags_flag_cr"]
+        flag_bad = ~cat["base_PixelFlags_flag_bad"]
+        flag_edge = ~cat["base_PixelFlags_flag_edge"]
+        allflags = flag_sat & flag_cr & flag_bad & flag_edge
+        return allflags
+
+    def filtPrimary(cat):
+        is_primary = cat["detect_isPrimary"]
+        return is_primary
+
+    allfilt = filtSNR(sourceCatalog) & filtExtended(sourceCatalog) &\
+              filtFlags(sourceCatalog) & filtPrimary(sourceCatalog) &\
+              filtMag(sourceCatalog)
+
+    return sourceCatalog[allfilt].copy(deep=True)

--- a/python/lsst/faro/utils/prefilter.py
+++ b/python/lsst/faro/utils/prefilter.py
@@ -79,4 +79,4 @@ def preFilter(
         filtFlags(sourceCatalog) & filtPrimary(sourceCatalog) &\
         filtMag(sourceCatalog)
 
-    return sourceCatalog[allfilt].copy(deep=True)
+    return sourceCatalog[allfilt]

--- a/python/lsst/faro/utils/prefilter.py
+++ b/python/lsst/faro/utils/prefilter.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from lsst.afw.table import GroupView
 
 __all__ = ("preFilter",)
 

--- a/tests/data/PA1_expected_0_i.yaml
+++ b/tests/data/PA1_expected_0_i.yaml
@@ -8,4 +8,4 @@ identifier: 170536d3e32d491ba65b0e86651672b9
 metric: PA1
 notes: {}
 unit: mmag
-value: 5.870064170916189
+value: 6.8097958

--- a/tests/data/PA1_expected_0_r.yaml
+++ b/tests/data/PA1_expected_0_r.yaml
@@ -8,4 +8,4 @@ identifier: d9882c7679974437980e33d992999a9c
 metric: PA1
 notes: {}
 unit: mmag
-value: 7.445174470432661
+value: 7.55641658

--- a/tests/data/PF1_expected_0_i.yaml
+++ b/tests/data/PF1_expected_0_i.yaml
@@ -8,4 +8,4 @@ identifier: adadccd0ced4428a9b736ab9ca1d4db4
 metric: PF1
 notes: {}
 unit: '%'
-value: 5.555555555555555
+value: 11.11111111

--- a/tests/data/PF1_expected_0_r.yaml
+++ b/tests/data/PF1_expected_0_r.yaml
@@ -8,4 +8,4 @@ identifier: 6a30324c265c402887d063147ecc4a3d
 metric: PF1
 notes: {}
 unit: '%'
-value: 5.263157894736842
+value: 13.54166667


### PR DESCRIPTION
Implemented filtering of catalogs before running multiMatch to create the matched catalogs. This involved:

a) writing a new "prefilter" function, which is called from matcher.py
b) adding config params to control the filtering to the base matched catalog class
c) re-writing some pipelines to allow for different cuts to be applied for different metrics (e.g., the "default" SNR cut for photometric repeatability, but magnitude ranges for astrometric repeatability)

Part (c) has the effect of writing additional matched catalogs rather than using the same one for all metrics. However, I thought it was worth the extra steps to make the entire pipeline more efficient. We could reconsider this if needed.

Some simple tests suggest that _for small amounts of data_, pipelines with prefiltering of catalogs before matching run in ~half the time, and use ~half the memory. It's possible that the effect will be more dramatic when processing large chunks of data.
