### PR TITLE
DM-31611: Improve reproducibility in ellipKPM test_te1

### DIFF
--- a/python/lsst/faro/measurement/TractMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractMeasurementTasks.py
@@ -122,6 +122,11 @@ class TExConfig(Config):
     column = Field(
         doc="Column to use for shape moments", dtype=str, default="slot_Shape"
     )
+    brute = Field(
+        doc="Run treecorr in brute-force mode for improved reproducibility in tests",
+        dtype=bool,
+        default=False
+    )
     # Eventually want to add option to use only PSF reserve stars
 
 

--- a/python/lsst/faro/utils/tex.py
+++ b/python/lsst/faro/utils/tex.py
@@ -462,6 +462,7 @@ def calculateTEx(data: List[CalibratedCatalog], config):
         min_sep=config.minSep,
         max_sep=config.maxSep,
         sep_units="arcmin",
+        brute=config.brute
     )
     rhoStatistics = RhoStatistics(
         config.column,

--- a/tests/data/TE1_expected_0_i.yaml
+++ b/tests/data/TE1_expected_0_i.yaml
@@ -8,4 +8,4 @@ identifier: cb5f325dc52f4ef794b3165b406c6fa4
 metric: TE1
 notes: {}
 unit: ''
-value: 0.0005146044101963828
+value: 0.0004407316609029412

--- a/tests/test_ellipKPM.py
+++ b/tests/test_ellipKPM.py
@@ -67,13 +67,14 @@ class Te1Test(unittest.TestCase):
         # This is what makes it TE1
         config.minSep = 0.25
         config.maxSep = 1.0
+        config.brute = True
         task = TExTask(config=config)
         for band in ('i',):
             catalog, expected = self.load_data(('TE1', band))
             result = task.run('TE1', {'i': [CalibratedCatalog(catalog), ]})
             log.debug('result: ', result)
             log.debug('expected: ', expected)
-            self.assertEqual(result.measurement, expected)
+            self.assertAlmostEqual(result.measurement, expected, places=10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Passing the brute-force parameter to treecorr ensures that the numerical answers in tests are the same across different
machine architectures.