### PR TITLE
DM-33700: Persist in-memory objects sent to metric measurement run method for offline analysis and development

### DIFF
--- a/pipelines/measurement/measurement_detector_table.yaml
+++ b/pipelines/measurement/measurement_detector_table.yaml
@@ -16,6 +16,10 @@ tasks:
       python: |
         from lsst.faro.base import NumSourcesTask
         config.measure.retarget(NumSourcesTask)
+        config.measure.columns={"detect_isPrimary": "detect_isPrimary",
+                                "detector": "detector"}
+        # Example for persisting in-memory inputs to metric measurement run method
+        # config.measure.shelveName="shelve.out"
         # Example configuration to apply proper motions for Gaia
         # config.referenceCatalogLoader.refObjLoader.ref_dataset_name = 'gaia_dr2_20200414'
         # config.referenceCatalogLoader.refObjLoader.requireProperMotion = True

--- a/python/lsst/faro/base/CatalogMeasurementBase.py
+++ b/python/lsst/faro/base/CatalogMeasurementBase.py
@@ -211,7 +211,7 @@ class CatalogMeasurementBaseTask(MetricTask):
         """
 
         import shelve
-        
+
         with shelve.open(shelveName, 'n') as shelf:
             shelf['config'] = config
             for key in kwargs.keys():

--- a/python/lsst/faro/base/CatalogMeasurementBase.py
+++ b/python/lsst/faro/base/CatalogMeasurementBase.py
@@ -99,6 +99,9 @@ class CatalogMeasurementBaseTask(MetricTask):
         self.makeSubtask("measure")
 
     def run(self, **kwargs):
+        if self.measure.config.shelveName:
+            # Persist in-memory objects for development and testing
+            self._persistMeasurementInputs(self.measure.config.shelveName, **kwargs)
         return self.measure.run(self.config.connections.metric, **kwargs)
 
     def _getTableColumnsSelectors(self, columns, currentBands=None):
@@ -192,3 +195,25 @@ class CatalogMeasurementBaseTask(MetricTask):
         refCatFrame = hstack([refCatTable, refCat.asAstropy()]).to_pandas()
 
         return refCatFrame
+
+    def _persistMeasurementInputs(self, shelveName, **kwargs):
+        """Persist in-memory objects sent as inputs to metric measurement run method.
+
+        This function is intended to be used for development and testing purposes
+        as a debug tool and is NOT to be used in routine operation.
+
+        Parameters
+        ----------
+        shelveName : `str`
+            Filename for output shelve.
+        """
+
+        import shelve
+        shelf = shelve.open(shelveName, 'n')
+
+        for key in kwargs.keys():
+            try:
+                shelf[key] = kwargs[key]
+            except TypeError:
+                print('ERROR shelving: {0}'.format(key))
+        shelf.close()

--- a/python/lsst/faro/base/CatalogMeasurementBase.py
+++ b/python/lsst/faro/base/CatalogMeasurementBase.py
@@ -99,9 +99,10 @@ class CatalogMeasurementBaseTask(MetricTask):
         self.makeSubtask("measure")
 
     def run(self, **kwargs):
-        if self.measure.config.shelveName:
-            # Persist in-memory objects for development and testing
-            self._persistMeasurementInputs(self.measure.config, self.measure.config.shelveName, **kwargs)
+        if 'shelveName' in self.measure.config.keys():
+            if self.measure.config.shelveName:
+                # Persist in-memory objects for development and testing
+                self._persistMeasurementInputs(self.measure.config, self.measure.config.shelveName, **kwargs)
         return self.measure.run(self.config.connections.metric, **kwargs)
 
     def _getTableColumnsSelectors(self, columns, currentBands=None):

--- a/python/lsst/faro/base/CatalogMeasurementBase.py
+++ b/python/lsst/faro/base/CatalogMeasurementBase.py
@@ -211,12 +211,11 @@ class CatalogMeasurementBaseTask(MetricTask):
         """
 
         import shelve
-        shelf = shelve.open(shelveName, 'n')
-
-        shelf['config'] = config
-        for key in kwargs.keys():
-            try:
-                shelf[key] = kwargs[key]
-            except TypeError:
-                print('ERROR shelving: {0}'.format(key))
-        shelf.close()
+        
+        with shelve.open(shelveName, 'n') as shelf:
+            shelf['config'] = config
+            for key in kwargs.keys():
+                try:
+                    shelf[key] = kwargs[key]
+                except TypeError:
+                    print('ERROR shelving: {0}'.format(key))

--- a/python/lsst/faro/base/CatalogMeasurementBase.py
+++ b/python/lsst/faro/base/CatalogMeasurementBase.py
@@ -216,7 +216,4 @@ class CatalogMeasurementBaseTask(MetricTask):
         with shelve.open(shelveName, 'n') as shelf:
             shelf['config'] = config
             for key in kwargs.keys():
-                try:
-                    shelf[key] = kwargs[key]
-                except TypeError:
-                    print('ERROR shelving: {0}'.format(key))
+                shelf[key] = kwargs[key]

--- a/python/lsst/faro/base/CatalogMeasurementBase.py
+++ b/python/lsst/faro/base/CatalogMeasurementBase.py
@@ -101,7 +101,7 @@ class CatalogMeasurementBaseTask(MetricTask):
     def run(self, **kwargs):
         if self.measure.config.shelveName:
             # Persist in-memory objects for development and testing
-            self._persistMeasurementInputs(self.measure.config.shelveName, **kwargs)
+            self._persistMeasurementInputs(self.measure.config, self.measure.config.shelveName, **kwargs)
         return self.measure.run(self.config.connections.metric, **kwargs)
 
     def _getTableColumnsSelectors(self, columns, currentBands=None):
@@ -196,7 +196,7 @@ class CatalogMeasurementBaseTask(MetricTask):
 
         return refCatFrame
 
-    def _persistMeasurementInputs(self, shelveName, **kwargs):
+    def _persistMeasurementInputs(self, config, shelveName, **kwargs):
         """Persist in-memory objects sent as inputs to metric measurement run method.
 
         This function is intended to be used for development and testing purposes
@@ -204,6 +204,8 @@ class CatalogMeasurementBaseTask(MetricTask):
 
         Parameters
         ----------
+        config : `lsst.pex.config.Config`
+            Config to be saved.
         shelveName : `str`
             Filename for output shelve.
         """
@@ -211,6 +213,7 @@ class CatalogMeasurementBaseTask(MetricTask):
         import shelve
         shelf = shelve.open(shelveName, 'n')
 
+        shelf['config'] = config
         for key in kwargs.keys():
             try:
                 shelf[key] = kwargs[key]

--- a/python/lsst/faro/base/ConfigBase.py
+++ b/python/lsst/faro/base/ConfigBase.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-from lsst.pex.config import Config, DictField
+from lsst.pex.config import Config, DictField, Field
 from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
 
 
@@ -42,6 +42,12 @@ class MeasurementTaskConfig(Config):
         keytype=str,
         itemtype=str,
         default={}
+    )
+    shelveName = Field(
+        doc="""Name of shelve file to persist in-memory objects set as input to metric
+        measurement run method.""",
+        dtype=str,
+        default="",
     )
 
     def _getColumnName(self, keyName, band=None):

--- a/python/lsst/faro/base/ConfigBase.py
+++ b/python/lsst/faro/base/ConfigBase.py
@@ -44,8 +44,8 @@ class MeasurementTaskConfig(Config):
         default={}
     )
     shelveName = Field(
-        doc="""Name of shelve file to persist in-memory objects set as input to metric
-        measurement run method.""",
+        doc="""Name of shelve file to persist in-memory objects sent as input to the metric
+        measurement run method. Used for testing, development, and debug work.""",
         dtype=str,
         default="",
     )

--- a/python/lsst/faro/measurement/DetectorTableMeasurement.py
+++ b/python/lsst/faro/measurement/DetectorTableMeasurement.py
@@ -61,10 +61,10 @@ class DetectorTableMeasurementConfig(
 
     def validate(self):
         super().validate()
-        if "detector" not in self.columns:
+        if "detector" not in self.measure.columns:
             msg = "The column `detector` must be appear in the list of columns."
             raise pexConfig.FieldValidationError(
-                DetectorTableMeasurementConfig.columns, self, msg
+                self.measure.ConfigClass.columns, self, msg
             )
 
 


### PR DESCRIPTION
This PR adds a helper function to persist in-memory objects sent to the metric measurement run method. This functionality is intended only to be used for development, testing, debugging, and diagnosis of anomalous metric values rather than standard operations. The helper function can be enabled via configuration.

To see how this works, add a line like the following to the yaml pipeline file

`config.measure.shelveName="shelve.out"`

and then to read the output file, at the python prompt (or in a notebook), use commands like the following

```
import shelve
filename = "shelve.out"
my_shelf = shelve.open(filename)
for key in my_shelf.keys(): print(key)
my_shelf['config']
my_shelf['catalog']
```