### PR TITLE
DM-33389: Update wPerp so it uses less memory

### DIFF
--- a/python/lsst/faro/measurement/TractTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractTableMeasurementTasks.py
@@ -163,7 +163,7 @@ class wPerpTableConfig(Config):
     config.measure.raColumn = "coord_ra_new"
     """
 
-    bright_rmag_cut  = Field(
+    bright_rmag_cut = Field(
         doc="Bright magnitude limit to select", dtype=float, default=17.0
     )
     faint_rmag_cut = Field(

--- a/python/lsst/faro/measurement/TractTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractTableMeasurementTasks.py
@@ -30,7 +30,6 @@ from lsst.faro.utils.extinction_corr import extinctionCorrTable
 from lsst.faro.utils.stellarLocus import stellarLocusFit
 from lsst.faro.utils.stats_utils import calcQuartileClippedStats
 
-# from scipy.stats import median_abs_deviation
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 import numpy as np
@@ -154,8 +153,8 @@ class TExTableTask(Task):
 
 class WPerpTableConfig(MeasurementTaskConfig):
     """Class to organize the yaml configuration parameters to be passed to
-    TExTableTask when using a parquet table input. All values needed to perform
-    TExTableTask have default values set below.
+    wPerpTableTask when using a parquet table input. All values needed to perform
+    wPerpTableTask have default values set below.
 
     Optional Input (yaml file)
     ----------
@@ -195,7 +194,7 @@ class WPerpTableConfig(MeasurementTaskConfig):
 
 
 class WPerpTableTask(Task):
-    """Class to perform the wPerp calculation on a parquet table data
+    """Class to perform the wPerp calculation on data from a parquet table
     object.
 
     Parameters
@@ -225,12 +224,6 @@ class WPerpTableTask(Task):
         catalog = selectors.applySelectors(catalog,
                                            self.config.selectorActions,
                                            currentBands=currentBands)
-
-        # Filter based on configured r-mag limits:
-        # rmag_tmp = (catalog.r_psfFlux.values*u.nJy).to(u.ABmag).value
-        # magfilter = (rmag_tmp < self.config.faint_rmag_cut) &\
-        #             (rmag_tmp > self.config.bright_rmag_cut)
-        # catalog = catalog[magfilter]
 
         # Create a SkyCoord object to get the extinction:
         sc = SkyCoord(catalog['coord_ra']*u.deg, catalog['coord_dec']*u.deg)

--- a/python/lsst/faro/measurement/TractTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractTableMeasurementTasks.py
@@ -249,7 +249,7 @@ class WPerpTableTask(Task):
                ((g0-r0) > fitParams['xMin']-magcushion)
 
         if np.size(p2vals[okp1]) > 2:
-            p2_mad = calcQuartileClippedStats(p2vals[okp1]).mad * u.mag
+            p2_sigmaMAD = calcQuartileClippedStats(p2vals[okp1]).sigmaMAD * u.mag
             extras = {
                 "wPerp_coeffs": Datum(
                     [fitParams['mODR2'], fitParams['bODR2']],
@@ -259,7 +259,7 @@ class WPerpTableTask(Task):
                 ),
             }
             return Struct(
-                measurement=Measurement(metricName, p2_mad.to(u.mmag), extras=extras)
+                measurement=Measurement(metricName, p2_sigmaMAD.to(u.mmag), extras=extras)
             )
         else:
             return Struct(measurement=Measurement(metricName, np.nan * u.mmag))

--- a/python/lsst/faro/measurement/TractTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractTableMeasurementTasks.py
@@ -234,16 +234,11 @@ class wPerpTableTask(Task):
         else:
             prependString = None
 
-        #import pdb; pdb.set_trace()
-        # print('catalog orig length: ', len(catalog))
-
         # filter catalog
         catalog = selectors.applySelectors(catalog,
                                            self.config.selectorActions,
                                            currentBands=currentBands)
-        
-        # print('catalog after selectors: ', len(catalog))
-
+       
         # Filter based on configured r-mag limits:
         # rmag_tmp = (catalog.r_psfFlux.values*u.nJy).to(u.ABmag).value
         # magfilter = (rmag_tmp < self.config.faint_rmag_cut) &\
@@ -273,14 +268,8 @@ class wPerpTableTask(Task):
                ((g0-r0) < fitParams['xMax']+magcushion) &\
                ((g0-r0) > fitParams['xMin']-magcushion)
 
-        # import pdb; pdb.set_trace()
-        # print('keepers: ', len(p2vals[okp1]), ' max mag: ', np.max(r0))
-
         if np.size(p2vals[okp1]) > 2:
-            p2_mad =  calcQuartileClippedStats(p2vals[okp1]).mad * u.mag
-            #p2_rms =  calcQuartileClippedStats(p2vals[okp1]).rms * u.mag
-            # p2_mad = median_abs_deviation(p2vals[okp1]) * u.mag
-            print(p2_mad.to(u.mmag))
+            p2_mad = calcQuartileClippedStats(p2vals[okp1]).mad * u.mag
             extras = {
                 "wPerp_coeffs": Datum(
                     [fitParams['mODR2'], fitParams['bODR2']],
@@ -288,7 +277,7 @@ class wPerpTableTask(Task):
                     label="wPerp_coefficients",
                     description="Slope, intercept coeffs from wPerp fit",
                 ),
-             }
+            }
             return Struct(
                 measurement=Measurement(metricName, p2_mad.to(u.mmag), extras=extras)
             )

--- a/python/lsst/faro/measurement/TractTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/TractTableMeasurementTasks.py
@@ -36,7 +36,7 @@ from astropy.coordinates import SkyCoord
 import numpy as np
 
 __all__ = ("TExTableConfig", "TExTableTask",
-           "wPerpTableConfig", "wPerpTableTask")
+           "WPerpTableConfig", "WPerpTableTask")
 
 
 class TExTableConfig(MeasurementTaskConfig):
@@ -152,7 +152,7 @@ class TExTableTask(Task):
         )
 
 
-class wPerpTableConfig(MeasurementTaskConfig):
+class WPerpTableConfig(MeasurementTaskConfig):
     """Class to organize the yaml configuration parameters to be passed to
     TExTableTask when using a parquet table input. All values needed to perform
     TExTableTask have default values set below.
@@ -167,12 +167,6 @@ class wPerpTableConfig(MeasurementTaskConfig):
     config.measure.raColumn = "coord_ra_new"
     """
 
-    #bright_rmag_cut = Field(
-    #    doc="Bright magnitude limit to select", dtype=float, default=17.0
-    #)
-    #faint_rmag_cut = Field(
-    #    doc="Faint magnitude limit to select", dtype=float, default=23.0
-    #)
     columns = DictField(
         doc="""Columns required for metric calculation. Should be all columns in SourceTable contexts,
         and columns that do not change name with band in ObjectTable contexts""",
@@ -180,14 +174,14 @@ class wPerpTableConfig(MeasurementTaskConfig):
         itemtype=str,
         default={"ra": "coord_ra",
                  "dec": "coord_dec",
-                }
+                 }
     )
     columnsBand = DictField(
         doc="""Columns required for metric calculation that change with band in ObjectTable contexts""",
         keytype=str,
         itemtype=str,
         default={"psfFlux": "psfFlux"
-                } ##### Check what columns are needed!
+                 }
     )
     stellarLocusFitDict = DictField(
         doc="The parameters to use for the stellar locus fit. The default parameters are examples and are "
@@ -200,7 +194,7 @@ class wPerpTableConfig(MeasurementTaskConfig):
     )
 
 
-class wPerpTableTask(Task):
+class WPerpTableTask(Task):
     """Class to perform the wPerp calculation on a parquet table data
     object.
 
@@ -213,7 +207,7 @@ class wPerpTableTask(Task):
     wPerp stellar locus metric with defined configuration.
     """
 
-    ConfigClass = wPerpTableConfig
+    ConfigClass = WPerpTableConfig
     _DefaultName = "wPerpTableTask"
 
     def run(
@@ -227,18 +221,11 @@ class wPerpTableTask(Task):
             self.log.warn("Data in gri bands required for wPerp calculation.")
             return Struct(measurement=Measurement(metricName, np.nan * u.mmag))
 
-        # If accessing objectTable_tract, we need to append the band name at
-        #   the beginning of the column name.
-        if currentBands is not None:
-            prependString = currentBands
-        else:
-            prependString = None
-
         # filter catalog
         catalog = selectors.applySelectors(catalog,
                                            self.config.selectorActions,
                                            currentBands=currentBands)
-       
+
         # Filter based on configured r-mag limits:
         # rmag_tmp = (catalog.r_psfFlux.values*u.nJy).to(u.ABmag).value
         # magfilter = (rmag_tmp < self.config.faint_rmag_cut) &\

--- a/python/lsst/faro/utils/extinction_corr.py
+++ b/python/lsst/faro/utils/extinction_corr.py
@@ -37,7 +37,45 @@ except ModuleNotFoundError as e:
         e.msg,
     )
 
-__all__ = ("extinction_corr",)
+__all__ = ("extinction_corr", "extinctionCorrTable",)
+
+
+def extinctionCorrTable(coords, bands):
+
+    # Extinction coefficients for HSC filters for conversion from E(B-V) to extinction, A_filter.
+    # Numbers provided by Masayuki Tanaka (NAOJ).
+    #
+    # Band, A_filter/E(B-V)
+    extinctionCoeffs_HSC = {
+        # See https://www.sdss.org/dr16/spectro/sspp/
+        # Assuming diff of ~0.65, given 0.553, 0.475, 0.453 for gri
+        "u": 4.505,
+        "g": 3.240,
+        "r": 2.276,
+        "i": 1.633,
+        "z": 1.263,
+        "y": 1.075,
+        "HSC-G": 3.240,
+        "HSC-R": 2.276,
+        "HSC-I": 1.633,
+        "HSC-Z": 1.263,
+        "HSC-Y": 1.075,
+        "NB0387": 4.007,
+        "NB0816": 1.458,
+        "NB0921": 1.187,
+    }
+
+    bands = list(bands)
+    sfd = SFDQuery()
+    ebvValues = sfd(coords)
+    extinction_dict = {"E(B-V)": ebvValues}
+
+    # Create a dict with the extinction values for each band (and E(B-V), too):
+    for band in bands:
+        coeff_name = "A_" + str(band)
+        extinction_dict[coeff_name] = ebvValues * extinctionCoeffs_HSC[band]
+
+    return extinction_dict
 
 
 def extinction_corr(catalog, bands):

--- a/python/lsst/faro/utils/selectors.py
+++ b/python/lsst/faro/utils/selectors.py
@@ -450,7 +450,6 @@ def applySelectors(catalog, selectorList, currentBands=None, returnMask=False):
     """
     mask = np.ones(len(catalog), dtype=bool)
     for selector in selectorList:
-        # import pdb; pdb.set_trace()
         mask &= selector(catalog, currentBands=currentBands)
     if returnMask:
         return catalog, mask
@@ -523,8 +522,6 @@ def brightIsolatedStarObjectTable(config):
     config.selectorActions.FlagSelector.selectorBandType = "currentBands"
     # setup per band flag selectors
     config.selectorActions.PerBandFlagSelector = PerBandFlagSelector
-    # config.selectorActions.PerBandFlagSelector.selectWhenFalse = ["pixelFlags_saturated", "pixelFlags_cr",
-    #                                                               "pixelFlags_bad", "pixelFlags_edge"]
     config.selectorActions.PerBandFlagSelector.selectWhenFalse = ["psfFlux_flag",
                                                                   "pixelFlags_saturatedCenter",
                                                                   "extendedness_flag"]

--- a/python/lsst/faro/utils/selectors.py
+++ b/python/lsst/faro/utils/selectors.py
@@ -450,6 +450,7 @@ def applySelectors(catalog, selectorList, currentBands=None, returnMask=False):
     """
     mask = np.ones(len(catalog), dtype=bool)
     for selector in selectorList:
+        # import pdb; pdb.set_trace()
         mask &= selector(catalog, currentBands=currentBands)
     if returnMask:
         return catalog, mask
@@ -518,10 +519,14 @@ def brightIsolatedStarObjectTable(config):
     # setup non band flag slectors
     config.selectorActions.FlagSelector = FlagSelector
     config.selectorActions.FlagSelector.selectWhenTrue = ["detect_isPrimary"]
+    config.selectorActions.FlagSelector.selectWhenFalse = ["xy_flag"]
     config.selectorActions.FlagSelector.selectorBandType = "currentBands"
     # setup per band flag selectors
     config.selectorActions.PerBandFlagSelector = PerBandFlagSelector
-    config.selectorActions.PerBandFlagSelector.selectWhenFalse = ["pixelFlags_saturated", "pixelFlags_cr",
-                                                                  "pixelFlags_bad", "pixelFlags_edge"]
+    # config.selectorActions.PerBandFlagSelector.selectWhenFalse = ["pixelFlags_saturated", "pixelFlags_cr",
+    #                                                               "pixelFlags_bad", "pixelFlags_edge"]
+    config.selectorActions.PerBandFlagSelector.selectWhenFalse = ["psfFlux_flag",
+                                                                  "pixelFlags_saturatedCenter",
+                                                                  "extendedness_flag"]
     config.selectorActions.PerBandFlagSelector.selectorBandType = "currentBands"
     return config

--- a/python/lsst/faro/utils/stats_utils.py
+++ b/python/lsst/faro/utils/stats_utils.py
@@ -75,14 +75,14 @@ def calcQuartileClippedStats(dataArray, nSigmaToClip=3.0):
     quartileClippedMean = dataArray[good].mean()
     quartileClippedStdDev = dataArray[good].std()
     quartileClippedRms = np.sqrt(np.mean(dataArray[good] ** 2))
-    quartileClippedMad = median_abs_deviation(dataArray[good])
+    quartileClippedSigmaMAD = median_abs_deviation(dataArray[good], scale='normal')
 
     return Struct(
         median=median,
         mean=quartileClippedMean,
         stdDev=quartileClippedStdDev,
         rms=quartileClippedRms,
-        mad=quartileClippedMad,
+        sigmaMAD=quartileClippedSigmaMAD,
         clipValue=clipValue,
         goodArray=good,
     )

--- a/python/lsst/faro/utils/stats_utils.py
+++ b/python/lsst/faro/utils/stats_utils.py
@@ -21,6 +21,7 @@
 
 import numpy as np
 from lsst.pipe.base import Struct
+from scipy.stats import median_abs_deviation
 
 __all__ = (
     "calcQuartileClippedStats",
@@ -71,12 +72,14 @@ def calcQuartileClippedStats(dataArray, nSigmaToClip=3.0):
     quartileClippedMean = dataArray[good].mean()
     quartileClippedStdDev = dataArray[good].std()
     quartileClippedRms = np.sqrt(np.mean(dataArray[good] ** 2))
+    quartileClippedMad = median_abs_deviation(dataArray[good])
 
     return Struct(
         median=median,
         mean=quartileClippedMean,
         stdDev=quartileClippedStdDev,
         rms=quartileClippedRms,
+        mad=quartileClippedMad,
         clipValue=clipValue,
         goodArray=good,
     )

--- a/python/lsst/faro/utils/stats_utils.py
+++ b/python/lsst/faro/utils/stats_utils.py
@@ -67,6 +67,9 @@ def calcQuartileClippedStats(dataArray, nSigmaToClip=3.0):
     assert len(quartiles) == 3
     median = quartiles[1]
     interQuartileDistance = quartiles[2] - quartiles[0]
+    # If the data array has a roughly Gaussian distribution,
+    # 0.74*interquartileDistance is an estimate of standard deviation.
+    # In that case, the following line is equivalent to nSigma clipping.
     clipValue = nSigmaToClip * 0.74 * interQuartileDistance
     good = np.logical_not(np.abs(dataArray - median) > clipValue)
     quartileClippedMean = dataArray[good].mean()

--- a/python/lsst/faro/utils/stats_utils.py
+++ b/python/lsst/faro/utils/stats_utils.py
@@ -1,0 +1,82 @@
+# This file is part of faro.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+from lsst.pipe.base import Struct
+
+__all__ = (
+    "calcQuartileClippedStats",
+)
+
+
+def calcQuartileClippedStats(dataArray, nSigmaToClip=3.0):
+    """Calculate the quartile-based clipped statistics of a data array.
+    The difference between quartiles[2] and quartiles[0] is the interquartile
+    distance.  0.74*interquartileDistance is an estimate of standard deviation
+    so, in the case that ``dataArray`` has an approximately Gaussian
+    distribution, this is equivalent to nSigma clipping.
+    Parameters
+    ----------
+    dataArray : `list` or `numpy.ndarray` of `float`
+        List or array containing the values for which the quartile-based
+        clipped statistics are to be calculated.
+    nSigmaToClip : `float`, optional
+        Number of \"sigma\" outside of which to clip data when computing the
+        statistics.
+    Returns
+    -------
+    result : `lsst.pipe.base.Struct`
+        The quartile-based clipped statistics with ``nSigmaToClip`` clipping.
+        Atributes are:
+        ``median``
+            The median of the full ``dataArray`` (`float`).
+        ``mean``
+            The quartile-based clipped mean (`float`).
+        ``stdDev``
+            The quartile-based clipped standard deviation (`float`).
+        ``rms``
+            The quartile-based clipped root-mean-squared (`float`).
+        ``clipValue``
+            The value outside of which to clip the data before computing the
+            statistics (`float`).
+        ``goodArray``
+            A boolean array indicating which data points in ``dataArray`` were
+            used in the calculation of the statistics, where `False` indicates
+            a clipped datapoint (`numpy.ndarray` of `bool`).
+    """
+    quartiles = np.percentile(dataArray, [25, 50, 75])
+    assert len(quartiles) == 3
+    median = quartiles[1]
+    interQuartileDistance = quartiles[2] - quartiles[0]
+    clipValue = nSigmaToClip * 0.74 * interQuartileDistance
+    good = np.logical_not(np.abs(dataArray - median) > clipValue)
+    quartileClippedMean = dataArray[good].mean()
+    quartileClippedStdDev = dataArray[good].std()
+    quartileClippedRms = np.sqrt(np.mean(dataArray[good] ** 2))
+
+    return Struct(
+        median=median,
+        mean=quartileClippedMean,
+        stdDev=quartileClippedStdDev,
+        rms=quartileClippedRms,
+        clipValue=clipValue,
+        goodArray=good,
+    )

--- a/python/lsst/faro/utils/stellarLocus.py
+++ b/python/lsst/faro/utils/stellarLocus.py
@@ -1,0 +1,223 @@
+# This file is part of faro.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+import scipy.stats as scipyStats
+import scipy.odr as scipyODR
+from lsst.pipe.base import Struct
+
+__all__ = (
+    "stellarLocusFit",
+    "perpDistance",
+)
+
+
+def stellarLocusFit(xs, ys, paramDict):
+    """Make a fit to the stellar locus
+    Parameters
+    ----------
+    xs : `numpy.ndarray`
+        The color on the xaxis
+    ys : `numpy.ndarray`
+        The color on the yaxis
+    paramDict : lsst.pex.config.dictField.Dict
+        A dictionary of parameters for line fitting
+        xMin : `float`
+            The minimum x edge of the box to use for initial fitting
+        xMax : `float`
+            The maximum x edge of the box to use for initial fitting
+        yMin : `float`
+            The minimum y edge of the box to use for initial fitting
+        yMax : `float`
+            The maximum y edge of the box to use for initial fitting
+        mHW : `float`
+            The hardwired gradient for the fit
+        bHW : `float`
+            The hardwired intercept of the fit
+    Returns
+    -------
+    paramsOut : `dict`
+        A dictionary of the calculated fit parameters
+        xMin : `float`
+            The minimum x edge of the box to use for initial fitting
+        xMax : `float`
+            The maximum x edge of the box to use for initial fitting
+        yMin : `float`
+            The minimum y edge of the box to use for initial fitting
+        yMax : `float`
+            The maximum y edge of the box to use for initial fitting
+        mHW : `float`
+            The hardwired gradient for the fit
+        bHW : `float`
+            The hardwired intercept of the fit
+        mODR : `float`
+            The gradient calculated by the ODR fit
+        bODR : `float`
+            The intercept calculated by the ODR fit
+        yBoxMin : `float`
+            The y value of the fitted line at xMin
+        yBoxMax : `float`
+            The y value of the fitted line at xMax
+        bPerpMin : `float`
+            The intercept of the perpendicular line that goes through xMin
+        bPerpMax : `float`
+            The intercept of the perpendicular line that goes through xMax
+        mODR2 : `float`
+            The gradient from the second round of fitting
+        bODR2 : `float`
+            The intercept from the second round of fitting
+        mPerp : `float`
+            The gradient of the line perpendicular to the line from the
+            second fit
+    Notes
+    -----
+    The code does two rounds of fitting, the first is initiated using the
+    hardwired values given in the `paramDict` parameter and is done using
+    an Orthogonal Distance Regression fit to the points defined by the
+    box of xMin, xMax, yMin and yMax. Once this fitting has been done a
+    perpendicular bisector is calculated at either end of the line and
+    only points that fall within these lines are used to recalculate the fit.
+    """
+
+    # Points to use for the fit
+    fitPoints = np.where((xs > paramDict["xMin"]) & (xs < paramDict["xMax"])
+                         & (ys > paramDict["yMin"]) & (ys < paramDict["yMax"]))[0]
+
+    linear = scipyODR.polynomial(1)
+
+    data = scipyODR.Data(xs[fitPoints], ys[fitPoints])
+    odr = scipyODR.ODR(data, linear, beta0=[paramDict["bHW"], paramDict["mHW"]])
+    params = odr.run()
+    mODR = float(params.beta[1])
+    bODR = float(params.beta[0])
+
+    paramsOut = {"xMin": paramDict["xMin"], "xMax": paramDict["xMax"], "yMin": paramDict["yMin"],
+                 "yMax": paramDict["yMax"], "mHW": paramDict["mHW"], "bHW": paramDict["bHW"],
+                 "mODR": mODR, "bODR": bODR}
+
+    # Having found the initial fit calculate perpendicular ends
+    mPerp = -1.0/mODR
+    # When the gradient is really steep we need to use
+    # the y limits of the box rather than the x ones
+
+    if np.fabs(mODR) > 1:
+        yBoxMin = paramDict["yMin"]
+        xBoxMin = (yBoxMin - bODR)/mODR
+        yBoxMax = paramDict["yMax"]
+        xBoxMax = (yBoxMax - bODR)/mODR
+    else:
+        yBoxMin = mODR*paramDict["xMin"] + bODR
+        xBoxMin = paramDict["xMin"]
+        yBoxMax = mODR*paramDict["xMax"] + bODR
+        xBoxMax = paramDict["xMax"]
+
+    bPerpMin = yBoxMin - mPerp*xBoxMin
+
+    paramsOut["yBoxMin"] = yBoxMin
+    paramsOut["bPerpMin"] = bPerpMin
+
+    bPerpMax = yBoxMax - mPerp*xBoxMax
+
+    paramsOut["yBoxMax"] = yBoxMax
+    paramsOut["bPerpMax"] = bPerpMax
+
+    # Use these perpendicular lines to chose the data and refit
+    fitPoints = ((ys > mPerp*xs + bPerpMin) & (ys < mPerp*xs + bPerpMax))
+    data = scipyODR.Data(xs[fitPoints], ys[fitPoints])
+    odr = scipyODR.ODR(data, linear, beta0=[bODR, mODR])
+    params = odr.run()
+    mODR = float(params.beta[1])
+    bODR = float(params.beta[0])
+
+    paramsOut["mODR2"] = float(params.beta[1])
+    paramsOut["bODR2"] = float(params.beta[0])
+
+    paramsOut["mPerp"] = -1.0/paramsOut["mODR2"]
+
+    # Calculate the fit lines for the entire X, Y range
+    ### UPDATE THIS TO CALCULATE FOR ALL COLORS RATHER THAN BETWEEN XMIN/YMIN - XMAX/YMAX!
+    xMinLine = np.min(xs)-0.2
+    xMaxLine = np.max(xs)+0.2
+    yMinLine = np.min(ys)-0.2
+    yMinLine = np.max(ys)+0.2
+
+    if np.fabs(paramsOut["mHW"]) > 1:
+        ysFitLineHW = np.array([yMinLIne, yMaxLine])
+        xsFitLineHW = (ysFitLineHW - paramsOut["bHW"])/paramsOut["mHW"]
+        ysFitLine = np.array([yMinLIne, yMaxLine])
+        xsFitLine = (ysFitLine - paramsOut["bODR"])/paramsOut["mODR"]
+        # "p1" is the position along the stellar locus.
+        # Evaluate p1 for all input points:
+        p1fit1 = (ys - paramsOut["bODR"])/paramsOut["mODR"]
+        ysFitLine2 = np.array([yMinLIne, yMaxLine])
+        xsFitLine2 = (ysFitLine2 - paramsOut["bODR2"])/paramsOut["mODR2"]
+        p1fit2 = (ys - paramsOut["bODR2"])/paramsOut["mODR2"]
+    else:
+        xsFitLineHW = np.array([xMinLine, xMaxLine])
+        ysFitLineHW = paramsOut["mHW"]*xsFitLineHW + paramsOut["bHW"]
+        xsFitLine = np.array([xMinLine, xMaxLine])
+        ysFitLine = [paramsOut["mODR"]*xsFitLine[0] + paramsOut["bODR"],
+                     paramsOut["mODR"]*xsFitLine[1] + paramsOut["bODR"]]
+        p1fit1 = [paramsOut["mODR"]*xs + paramsOut["bODR"]]
+        xsFitLine2 = np.array([xMinLine, xMaxLine])
+        ysFitLine2 = [paramsOut["mODR2"]*xsFitLine2[0] + paramsOut["bODR2"],
+                      paramsOut["mODR2"]*xsFitLine2[1] + paramsOut["bODR2"]]
+        p1fit2 = [paramsOut["mODR2"]*xs + paramsOut["bODR2"]]
+
+    # Calculate the distances to the fit line
+    # Need two points to characterise the lines we want
+    # to get the distances to
+    pt1 = np.array([xsFitLine2[0], ysFitLine2[0]])
+    pt2 = np.array([xsFitLine2[1], ysFitLine2[1]])
+
+    pt1HW = np.array([xsFitLine2[0], ysFitLineHW[0]])
+    pt2HW = np.array([xsFitLine2[1], ysFitLineHW[1]])
+
+    # "p2" is the distance from the fit line
+    p2HW = perpDistance(pt1HW, pt2HW, zip(xs, ys))
+    p2 = perpDistance(pt1, pt2, zip(xs, ys))
+
+    return np.array(p1fit2), np.array(p2), paramsOut
+
+
+def perpDistance(pt1, pt2, points):
+    """Calculate the perpendicular distance to a line from a point
+    Parameters
+    ----------
+    pt1 : `numpy.ndarray`
+         A point on the line
+    pt2 : `numpy.ndarray`
+         Another point on the line
+    points : `zip`
+        The points to calculate the distance to
+    Returns
+    -------
+    dists : `list`
+        The distances from the line to the points. Uses the cross
+        product to work this out.
+    """
+    dists = []
+    for point in points:
+        point = np.array(point)
+        distToLine = np.cross(pt1 - point, pt2 - point)/np.linalg.norm(pt2 - point)
+        dists.append(distToLine)
+
+    return dists

--- a/python/lsst/faro/utils/stellarLocus.py
+++ b/python/lsst/faro/utils/stellarLocus.py
@@ -20,9 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-import scipy.stats as scipyStats
 import scipy.odr as scipyODR
-from lsst.pipe.base import Struct
 
 __all__ = (
     "stellarLocusFit",
@@ -153,20 +151,19 @@ def stellarLocusFit(xs, ys, paramDict):
     paramsOut["mPerp"] = -1.0/paramsOut["mODR2"]
 
     # Calculate the fit lines for the entire X, Y range
-    ### UPDATE THIS TO CALCULATE FOR ALL COLORS RATHER THAN BETWEEN XMIN/YMIN - XMAX/YMAX!
     xMinLine = np.min(xs)-0.2
     xMaxLine = np.max(xs)+0.2
     yMinLine = np.min(ys)-0.2
-    yMinLine = np.max(ys)+0.2
+    yMaxLine = np.max(ys)+0.2
 
     if np.fabs(paramsOut["mHW"]) > 1:
-        ysFitLineHW = np.array([yMinLIne, yMaxLine])
+        ysFitLineHW = np.array([yMinLine, yMaxLine])
         xsFitLineHW = (ysFitLineHW - paramsOut["bHW"])/paramsOut["mHW"]
         yFiducialHW = np.array(paramsOut['yMin'])
         xFiducialHW = (yFiducialHW - paramsOut["bODR"])/paramsOut["mODR"]
-        ysFitLine = np.array([yMinLIne, yMaxLine])
+        ysFitLine = np.array([yMinLine, yMaxLine])
         xsFitLine = (ysFitLine - paramsOut["bODR"])/paramsOut["mODR"]
-        ysFitLine2 = np.array([yMinLIne, yMaxLine])
+        ysFitLine2 = np.array([yMinLine, yMaxLine])
         xsFitLine2 = (ysFitLine2 - paramsOut["bODR2"])/paramsOut["mODR2"]
         yFiducial = np.array(paramsOut['yMin'])
         xFiducial = (yFiducial - paramsOut["bODR2"])/paramsOut["mODR2"]

--- a/python/lsst/faro/utils/stellarLocus.py
+++ b/python/lsst/faro/utils/stellarLocus.py
@@ -224,7 +224,7 @@ def parallelPerpDistance(pt1, pt2, points):
     for point in points:
         point = np.array(point)
         distToLine = np.cross(pt1 - point, pt2 - point)/np.linalg.norm(pt2 - pt1)
-        distAlongLine = np.sqrt(distToLine**2 + (np.linalg.norm(pt1 - point))**2)
+        distAlongLine = np.sqrt((np.linalg.norm(pt1 - point))**2 - distToLine**2)
         sign = np.sign((point - pt1)/np.linalg.norm(point - pt1))[0]
         dists_perp.append(distToLine)
         dists_parallel.append(sign*distAlongLine)


### PR DESCRIPTION
This ticket implements a version of the stellar locus metric "wPerp" that uses the `objectTable_tract` parquet table rather than afw tables. Some of the functionality that was in place for the afw table version has been moved to new functions (e.g., the extinction correction and statistics modules), and the previous modules for those tasks will be removed once we have completed moving all `faro` tasks to using parquet.

The main task is in WPerpTableTask (and associated config). This calls the utility function "stellarLocus.py", which is adapted from the stellar locus fitting routine [in analysis_drp](https://github.com/lsst/analysis_drp/blob/d731aa6f7bf9ed2f43516390766ad6ee939f4f60/python/lsst/analysis/drp/plotUtils.py#L112). Notable changes relative to the analysis_drp version include:

1. Fixed a bug in the "perpDistance" algorithm. The normalization `np.linalg.norm(p2 - point)` was incorrect, and should instead be `np.linalg.norm(pt2 - pt1)`. (This was artificially inflating the wPerp values by a factor of ~20%.)
2. Added an additional calculation of the "parallel" distance along the best-fit line (relative to a fiducial point). (This is "p1" in the case of the wPerp metric.)

Another important change is updating the default flags for `brightIsolatedStarObjectTable`. The flags that were previously used were inappropriate for the object table.