### PR TITLE
DM-32613 Update faro photometric repeatability measurement tasks to use parquet table inputs

### DIFF
--- a/pipelines/example/measurement_tract_matched_catalog_example.yaml
+++ b/pipelines/example/measurement_tract_matched_catalog_example.yaml
@@ -1,27 +1,27 @@
 description: Compute per-visit metrics from sourceTable_visit catalogs
 tasks:
-  nsrcMeasMatchedTable:
-    class: lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask
-    config:
-      connections.package: info
-      connections.metric: nsrcMeasMatchedTable
-      connections.individualSourceCatalogName: isolated_star_sources
-      python: |
-        from lsst.faro.base import NumSourcesTask
-        import lsst.faro.utils.selectors as selectors
-        config.measure.retarget(NumSourcesTask)
-        config.measure.columns={"ra":"ra","band":"band"}
-  nsrcMeasMatchedMultiBandTable:
-    class: lsst.faro.measurement.TractMatchedCatalogMultiBandTableMeasurementTask
-    config:
-      connections.package: info
-      connections.metric: nsrcMeasMatchedMultiBandTable
-      connections.individualSourceCatalogName: isolated_star_sources
-      python: |
-        from lsst.faro.base import NumSourcesTask
-        import lsst.faro.utils.selectors as selectors
-        config.measure.retarget(NumSourcesTask)
-        config.measure.columns={"ra":"ra","band":"band"}
+  # nsrcMeasMatchedTable:
+  #   class: lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask
+  #   config:
+  #     connections.package: info
+  #     connections.metric: nsrcMeasMatchedTable
+  #     connections.individualSourceCatalogName: isolated_star_sources
+  #     python: |
+  #       from lsst.faro.base import NumSourcesTask
+  #       import lsst.faro.utils.selectors as selectors
+  #       config.measure.retarget(NumSourcesTask)
+  #       config.measure.columns={"ra":"ra","band":"band"}
+  # nsrcMeasMatchedMultiBandTable:
+  #   class: lsst.faro.measurement.TractMatchedCatalogMultiBandTableMeasurementTask
+  #   config:
+  #     connections.package: info
+  #     connections.metric: nsrcMeasMatchedMultiBandTable
+  #     connections.individualSourceCatalogName: isolated_star_sources
+  #     python: |
+  #       from lsst.faro.base import NumSourcesTask
+  #       import lsst.faro.utils.selectors as selectors
+  #       config.measure.retarget(NumSourcesTask)
+  #       config.measure.columns={"ra":"ra","band":"band"}
   PA1MatchedTable:
     class: lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask
     config:
@@ -32,5 +32,17 @@ tasks:
         from lsst.faro.measurement.MatchedCatalogTableMeasurementTasks import PA1TableTask
         import lsst.faro.utils.selectors as selectors
         config.measure.retarget(PA1TableTask)
+        config.measure.columns={"ra":"ra","band":"band",'flux':'apFlux_12_0_instFlux',
+        'fluxErr':'apFlux_12_0_instFluxErr', 'objectID':'obj_index'}
+  PF1MatchedTable:
+    class: lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask
+    config:
+      connections.package: info
+      connections.metric: PF1MatchedTable
+      connections.individualSourceCatalogName: isolated_star_sources
+      python: |
+        from lsst.faro.measurement.MatchedCatalogTableMeasurementTasks import PF1TableTask
+        import lsst.faro.utils.selectors as selectors
+        config.measure.retarget(PF1TableTask)
         config.measure.columns={"ra":"ra","band":"band",'flux':'apFlux_12_0_instFlux',
         'fluxErr':'apFlux_12_0_instFluxErr', 'objectID':'obj_index'}

--- a/pipelines/example/measurement_tract_matched_catalog_example.yaml
+++ b/pipelines/example/measurement_tract_matched_catalog_example.yaml
@@ -1,32 +1,32 @@
 description: Compute per-visit metrics from sourceTable_visit catalogs
 tasks:
-  # nsrcMeasMatchedTable:
-  #   class: lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask
-  #   config:
-  #     connections.package: info
-  #     connections.metric: nsrcMeasMatchedTable
-  #     connections.individualSourceCatalogName: isolated_star_sources
-  #     python: |
-  #       from lsst.faro.base import NumSourcesTask
-  #       import lsst.faro.utils.selectors as selectors
-  #       config.measure.retarget(NumSourcesTask)
-  #       config.measure.columns={"ra":"ra","band":"band"}
-  # nsrcMeasMatchedMultiBandTable:
-  #   class: lsst.faro.measurement.TractMatchedCatalogMultiBandTableMeasurementTask
-  #   config:
-  #     connections.package: info
-  #     connections.metric: nsrcMeasMatchedMultiBandTable
-  #     connections.individualSourceCatalogName: isolated_star_sources
-  #     python: |
-  #       from lsst.faro.base import NumSourcesTask
-  #       import lsst.faro.utils.selectors as selectors
-  #       config.measure.retarget(NumSourcesTask)
-  #       config.measure.columns={"ra":"ra","band":"band"}
-  PA1MatchedTable3:
+  nsrcMeasMatchedTable:
     class: lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask
     config:
       connections.package: info
-      connections.metric: PA1MatchedTable3
+      connections.metric: nsrcMeasMatchedTable
+      connections.individualSourceCatalogName: isolated_star_sources
+      python: |
+        from lsst.faro.base import NumSourcesTask
+        import lsst.faro.utils.selectors as selectors
+        config.measure.retarget(NumSourcesTask)
+        config.measure.columns={"ra":"ra","band":"band"}
+  nsrcMeasMatchedMultiBandTable:
+    class: lsst.faro.measurement.TractMatchedCatalogMultiBandTableMeasurementTask
+    config:
+      connections.package: info
+      connections.metric: nsrcMeasMatchedMultiBandTable
+      connections.individualSourceCatalogName: isolated_star_sources
+      python: |
+        from lsst.faro.base import NumSourcesTask
+        import lsst.faro.utils.selectors as selectors
+        config.measure.retarget(NumSourcesTask)
+        config.measure.columns={"ra":"ra","band":"band"}
+  PA1MatchedTable:
+    class: lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask
+    config:
+      connections.package: info
+      connections.metric: PA1MatchedTable
       connections.individualSourceCatalogName: isolated_star_sources
       python: |
         from lsst.faro.measurement.MatchedCatalogTableMeasurementTasks import PA1TableTask
@@ -59,6 +59,6 @@ tasks:
         config.measure.selectorActions.SNRSelector.selectorBandType = "currentBands"
         config.measure.selectorActions.FlagSelector = selectors.FlagSelector
         config.measure.selectorActions.FlagSelector.selectWhenFalse = ['apFlux_12_0_instFluxFlag']
-        
+
         config.measure.columns={"ra":"ra","band":"band",'flux':'apFlux_12_0_instFlux',
         'fluxErr':'apFlux_12_0_instFluxErr', 'objectID':'obj_index'}

--- a/pipelines/example/measurement_tract_matched_catalog_example.yaml
+++ b/pipelines/example/measurement_tract_matched_catalog_example.yaml
@@ -22,3 +22,15 @@ tasks:
         import lsst.faro.utils.selectors as selectors
         config.measure.retarget(NumSourcesTask)
         config.measure.columns={"ra":"ra","band":"band"}
+  PA1MatchedTable:
+    class: lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask
+    config:
+      connections.package: info
+      connections.metric: PA1MatchedTable
+      connections.individualSourceCatalogName: isolated_star_sources
+      python: |
+        from lsst.faro.measurement.MatchedCatalogTableMeasurementTasks import PA1TableTask
+        import lsst.faro.utils.selectors as selectors
+        config.measure.retarget(PA1TableTask)
+        config.measure.columns={"ra":"ra","band":"band",'flux':'apFlux_12_0_instFlux',
+        'fluxErr':'apFlux_12_0_instFluxErr', 'objectID':'obj_index'}

--- a/pipelines/example/measurement_tract_matched_catalog_example.yaml
+++ b/pipelines/example/measurement_tract_matched_catalog_example.yaml
@@ -34,14 +34,14 @@ tasks:
         config.measure.retarget(PA1TableTask)
 
         config.measure.selectorActions.SNRSelector = selectors.SNRSelector
-        config.measure.selectorActions.SNRSelector.fluxType = "apFlux_12_0_instFlux"
-        config.measure.selectorActions.SNRSelector.snrMin = 20
+        config.measure.selectorActions.SNRSelector.fluxType = "psfFlux"
+        config.measure.selectorActions.SNRSelector.snrMin = 50
         config.measure.selectorActions.SNRSelector.selectorBandType = "currentBands"
         config.measure.selectorActions.FlagSelector = selectors.FlagSelector
-        config.measure.selectorActions.FlagSelector.selectWhenFalse = ['apFlux_12_0_instFluxFlag']
+        config.measure.selectorActions.FlagSelector.selectWhenFalse = ['apFlux_17_0_flag']
         
-        config.measure.columns={"ra":"ra","band":"band",'flux':'apFlux_12_0_instFlux',
-        'fluxErr':'apFlux_12_0_instFluxErr', 'objectID':'obj_index'}
+        config.measure.columns={"ra":"ra","band":"band",'flux':'psfFlux',
+        'fluxErr':'psfFluxErr', 'objectID':'obj_index'}
   PF1MatchedTable:
     class: lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask
     config:
@@ -54,11 +54,11 @@ tasks:
         config.measure.retarget(PF1TableTask)
 
         config.measure.selectorActions.SNRSelector = selectors.SNRSelector
-        config.measure.selectorActions.SNRSelector.fluxType = "apFlux_12_0_instFlux"
-        config.measure.selectorActions.SNRSelector.snrMin = 20
+        config.measure.selectorActions.SNRSelector.fluxType = "psfFlux"
+        config.measure.selectorActions.SNRSelector.snrMin = 50
         config.measure.selectorActions.SNRSelector.selectorBandType = "currentBands"
         config.measure.selectorActions.FlagSelector = selectors.FlagSelector
-        config.measure.selectorActions.FlagSelector.selectWhenFalse = ['apFlux_12_0_instFluxFlag']
+        config.measure.selectorActions.FlagSelector.selectWhenFalse = ['apFlux_17_0_flag']
 
-        config.measure.columns={"ra":"ra","band":"band",'flux':'apFlux_12_0_instFlux',
-        'fluxErr':'apFlux_12_0_instFluxErr', 'objectID':'obj_index'}
+        config.measure.columns={"ra":"ra","band":"band",'flux':'psfFlux',
+        'fluxErr':'psfFluxErr', 'objectID':'obj_index'}

--- a/pipelines/example/measurement_tract_matched_catalog_example.yaml
+++ b/pipelines/example/measurement_tract_matched_catalog_example.yaml
@@ -39,7 +39,7 @@ tasks:
         config.measure.selectorActions.SNRSelector.selectorBandType = "currentBands"
         config.measure.selectorActions.FlagSelector = selectors.FlagSelector
         config.measure.selectorActions.FlagSelector.selectWhenFalse = ['apFlux_17_0_flag']
-        
+
         config.measure.columns={"ra":"ra","band":"band",'flux':'psfFlux',
         'fluxErr':'psfFluxErr', 'objectID':'obj_index'}
   PF1MatchedTable:

--- a/pipelines/example/measurement_tract_matched_catalog_example.yaml
+++ b/pipelines/example/measurement_tract_matched_catalog_example.yaml
@@ -22,16 +22,24 @@ tasks:
   #       import lsst.faro.utils.selectors as selectors
   #       config.measure.retarget(NumSourcesTask)
   #       config.measure.columns={"ra":"ra","band":"band"}
-  PA1MatchedTable:
+  PA1MatchedTable3:
     class: lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask
     config:
       connections.package: info
-      connections.metric: PA1MatchedTable
+      connections.metric: PA1MatchedTable3
       connections.individualSourceCatalogName: isolated_star_sources
       python: |
         from lsst.faro.measurement.MatchedCatalogTableMeasurementTasks import PA1TableTask
         import lsst.faro.utils.selectors as selectors
         config.measure.retarget(PA1TableTask)
+
+        config.measure.selectorActions.SNRSelector = selectors.SNRSelector
+        config.measure.selectorActions.SNRSelector.fluxType = "apFlux_12_0_instFlux"
+        config.measure.selectorActions.SNRSelector.snrMin = 20
+        config.measure.selectorActions.SNRSelector.selectorBandType = "currentBands"
+        config.measure.selectorActions.FlagSelector = selectors.FlagSelector
+        config.measure.selectorActions.FlagSelector.selectWhenFalse = ['apFlux_12_0_instFluxFlag']
+        
         config.measure.columns={"ra":"ra","band":"band",'flux':'apFlux_12_0_instFlux',
         'fluxErr':'apFlux_12_0_instFluxErr', 'objectID':'obj_index'}
   PF1MatchedTable:
@@ -44,5 +52,13 @@ tasks:
         from lsst.faro.measurement.MatchedCatalogTableMeasurementTasks import PF1TableTask
         import lsst.faro.utils.selectors as selectors
         config.measure.retarget(PF1TableTask)
+
+        config.measure.selectorActions.SNRSelector = selectors.SNRSelector
+        config.measure.selectorActions.SNRSelector.fluxType = "apFlux_12_0_instFlux"
+        config.measure.selectorActions.SNRSelector.snrMin = 20
+        config.measure.selectorActions.SNRSelector.selectorBandType = "currentBands"
+        config.measure.selectorActions.FlagSelector = selectors.FlagSelector
+        config.measure.selectorActions.FlagSelector.selectWhenFalse = ['apFlux_12_0_instFluxFlag']
+        
         config.measure.columns={"ra":"ra","band":"band",'flux':'apFlux_12_0_instFlux',
         'fluxErr':'apFlux_12_0_instFluxErr', 'objectID':'obj_index'}

--- a/python/lsst/faro/measurement/MatchedCatalogTableMeasurement.py
+++ b/python/lsst/faro/measurement/MatchedCatalogTableMeasurement.py
@@ -87,7 +87,7 @@ class TractMatchedCatalogTableMeasurementTask(CatalogMeasurementBaseTask):
         columns = list(self.config.measure.columns.values())
         for column in self.config.measure.columnsBand.values():
             columns.append(kwargs["currentBands"] + '_' + column)
-        columnsWithSelectors = self._getTableColumnsSelectors(columns, kwargs["currentBands"])
+        columnsWithSelectors = self._getTableColumnsSelectors(columns, None)
         catalog = inputs["individualSourceCatalog"].get(parameters={"columns": columnsWithSelectors})
         sel = (catalog[self.config.measure._getColumnName("band")] == kwargs["currentBands"])
         kwargs["catalog"] = catalog.loc[sel, :]

--- a/python/lsst/faro/measurement/MatchedCatalogTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/MatchedCatalogTableMeasurementTasks.py
@@ -24,7 +24,7 @@ from lsst.verify import Measurement, Datum
 
 from lsst.faro.base.ConfigBase import MeasurementTaskConfig
 import lsst.faro.utils.selectors as selectors
-from lsst.faro.utils.tex_table import calculateTEx
+from lsst.faro.utils.phot_repeat_table import calcPhotRepeatTable
 
 import astropy.units as u
 import numpy as np
@@ -42,14 +42,130 @@ class PA1TableConfig(MeasurementTaskConfig):
         default=50,
     )
     meanSNRCut = Field(
-        doc="Minimum mean Signal to Noise ratio for source to be incuded in PA1",
-        dtype=int,
+        doc="""Minimum mean Signal to Noise ratio over all observations of a source 
+            for source to be incuded in PA1""",
+        dtype=float,
         default=50,
     )
     writeExtras = Field(
         doc="Write out the magnitude residuals and rms values for debugging.",
         dtype=bool,
         default=False,
+    )
+    columns = DictField(
+        doc="""Columns required for metric calculation. Should be all columns in SourceTable contexts,
+        and columns that do not change name with band in ObjectTable contexts""",
+        keytype=str,
+        itemtype=str,
+        default={"ra": "coord_ra",
+                 "dec": "coord_dec",
+                 "flux": "psfFlux",
+                 "fluxErr":"psfFluxErr",
+                 "fluxFlag":"psfFluxFlag",
+                 "objectID":"obj_index",
+                 }
+    )
+    columnsBand = DictField(
+        doc="""Columns required for metric calculation that change with band in ObjectTable contexts""",
+        keytype=str,
+        itemtype=str,
+        default={}
+    ) 
+
+class PA1TableTask(Task):
+    """Class to perform the PA1 calculation on a Matched parquet Source Table. 
+    PA1 is the photometric repeatability metric from an input set of multiple 
+    visits of the same field.
+
+    Parameters
+    ----------
+    Matched Catalog: pandas dataframe with group index column
+
+    Output:
+    ----------
+    PA1 metric with defined configuration.
+    """
+
+    ConfigClass = PA1TableConfig
+    _DefaultName = "PA1TableTask"
+
+    def run(
+        self, metricName, catalog, currentBands, **kwargs
+    ):
+
+        self.log.info("Measuring %s", metricName)
+        
+        # filter catalog        
+        catalog = selectors.applySelectors(catalog,
+                                           self.config.selectorActions,
+                                           currentBands=currentBands)
+        
+        objectidColumn=self.config._getColumnName("objectID", currentBands)
+        fluxColumn=self.config._getColumnName("flux", currentBands)
+        fluxErrColumn=self.config._getColumnName("fluxErr", currentBands)
+        
+        # compute aggregated values
+        photRepeatFrame=calcPhotRepeatTable(catalog,
+                                            objectidColumn,
+                                            fluxColumn,
+                                            fluxErrColumn,
+                                            residuals=False
+                                            )
+
+        okRms=(photRepeatFrame[("count")] > 2)
+        okMeanSNR=(photRepeatFrame['meanSnr']> self.config.meanSNRCut)
+        
+        #compute PA1 metric          
+        repeatability=(np.median(photRepeatFrame.loc[okRms & okMeanSNR,("rms")])*u.mag).to(u.mmag)
+        self.log.info("Median rms = %i mmag" % repeatability.value)
+
+        if ("magMean" in photRepeatFrame.columns) and ((okRms & okMeanSNR).sum() > self.config.nMinPhotRepeat):
+            if self.config.writeExtras:
+                extras = {
+                    "rms": Datum(
+                        (photRepeatFrame["rms"].values*u.mag).to(u.mmag),
+                        label="RMS",
+                        description="Photometric repeatability rms for each star.",
+                    ),
+                    "count": Datum(
+                        photRepeatFrame["count"].values * u.count,
+                        label="count",
+                        description="Number of detections used to calculate repeatability.",
+                    ),
+                    "mean_mag": Datum(
+                        photRepeatFrame["magMean"].values * u.mag,
+                        label="mean_mag",
+                        description="Mean magnitude of each star.",
+                    ),
+                }
+                return Struct(
+                    measurement=Measurement("PA1", repeatability, extras=extras)
+                )
+            else:
+                return Struct(measurement=Measurement("PA1", repeatability))
+        else:
+            return Struct(measurement=Measurement("PA1", np.nan * u.mmag))
+
+class PF1TableConfig(MeasurementTaskConfig):
+    nMinPhotRepeat = Field(
+        doc="Minimum number of objects required for photometric repeatability.",
+        dtype=int,
+        default=50,
+    )
+    meanSNRCut = Field(
+        doc="""Minimum mean Signal to Noise ratio over all observations of a source 
+            for source to be incuded in PA1""",
+        dtype=float,
+        default=50,
+    )
+    writeExtras = Field(
+        doc="Write out the magnitude residuals and rms values for debugging.",
+        dtype=bool,
+        default=False,
+    )
+    # The defaults for threshPA2 correspond to the SRD "design" thresholds.
+    threshPA2 = Field(
+        doc="Threshold in mmag for PF1 calculation.", dtype=float, default=15.0
     )
     columns = DictField(
         doc="""Columns required for metric calculation. Should be all columns in SourceTable contexts,
@@ -70,32 +186,44 @@ class PA1TableConfig(MeasurementTaskConfig):
         default={}
     ) 
 
-class PA1TableTask(Task):
-    """Class to perform the PA1 calculation on a ForcedSource parquet Object Table. 
-    PA1 is the photometric repeatability metric from an input set of multiple 
-    visits of the same field.
 
-    Parameters
-    ----------
-    None
+class PF1TableTask(Task):
+    """A Task that computes PF1, the percentage of photometric repeatability measurements
+    that deviate by more than PA2 mmag from the mean.
 
-    Output:
-    ----------
-    PA1 metric with defined configuration.
+    Notes
+    -----
+    The intended usage is to retarget the run method of
+    `lsst.faro.measurement.TractMatchedCatalogTableMeasurementTask` to PF1Task. This Task uses the
+    same set of photometric residuals that are calculated for the PA1 metric.
+    This metric is calculated on a set of matched visits, and aggregated at the tract level.
     """
 
-    ConfigClass = PA1TableConfig
-    _DefaultName = "PA1TableTask"
+    ConfigClass = PF1TableConfig
+    _DefaultName = "PF1TableTask"
 
     def run(
         self, metricName, catalog, currentBands, **kwargs
     ):
+        """Calculate the percentage of outliers in the photometric repeatability values.
 
+        Parameters
+        ----------
+        Matched Catalog: 
+            pandas dataframe of SourceTable observations with group index column
+
+        metricName : `str`
+            The name of the metric.
+
+        Returns
+        -------
+        measurement : `lsst.verify.Measurement`
+            Measurement of the percentage of repeatability outliers, and associated metadata.
+        """
         self.log.info("Measuring %s", metricName)
-        
-        # filter catalog
-        # Select bright isolated s/n filter 20 for pre aggregate cuts
-        
+        pa2_thresh = self.config.threshPA2 * u.mmag
+
+        # filter catalog        
         catalog = selectors.applySelectors(catalog,
                                            self.config.selectorActions,
                                            currentBands=currentBands)
@@ -104,65 +232,27 @@ class PA1TableTask(Task):
         fluxColumn=self.config._getColumnName("flux", currentBands)
         fluxErrColumn=self.config._getColumnName("fluxErr", currentBands)
         
-        magColumn=self.config._getColumnName("flux", currentBands).replace("Flux","Mag")
-        mags=(catalog.loc[:,fluxColumn].values*u.nJy).to(u.ABmag).value
-        catalog=catalog.assign(**{magColumn:mags})
-        
         # compute aggregated values
-        photRepeatFrame=catalog.groupby(
-                                        objectidColumn
-                                    ).aggregate(
-                                            {magColumn:[
-                                                np.nanstd,
-                                                np.count_nonzero,
-                                                np.mean
-                                            ]
-                                        }
-                                    ).rename(
-                                        columns={
-                                            'nanstd': 'rms',
-                                            'count_nonzero':'count',
-                                            "mean":"magMean"
-                                        }
-                                    )
-        photRepeatFrame.loc[:,"meanSnr"]=catalog.groupby(
-                                                   objectidColumn
-                                                ).apply(
-                                                    lambda row: np.mean(row[fluxColumn]/row[fluxErrColumn])
-                                                    )
-                                  
-        photRepeatFrame.loc[:,"residuals"]=catalog.groupby(
-                                                    objectidColumn
-                                                )[magColumn].apply(lambda x:np.array(x-np.mean(x)))
-        okRms=(photRepeatFrame[(magColumn,"count")] > 2)
-        okMeanSNR=(photRepeatFrame['meanSnr']> self.config.meanSNRCut)
+        photRepeatFrame = calcPhotRepeatTable(catalog,
+                                            objectidColumn,
+                                            fluxColumn,
+                                            fluxErrColumn,
+                                            residuals=True
+                                            )
 
-        #compute pa1 metric          
-        repeatability=(np.median(photRepeatFrame.loc[okRms & okMeanSNR,(magColumn,"rms")])*u.mag).to(u.mmag)
-        self.log.info("Median rms = %i mmag" % repeatability.value)
-        if ((magColumn, "magMean") in photRepeatFrame.columns) and (okRms & okMeanSNR).sum() > self.config.nMinPhotRepeat:
-            if self.config.writeExtras:
-                extras = {
-                    "rms": Datum(
-                        (photRepeatFrame[(magColumn,"rms")].values*u.mag).to(u.mmag),
-                        label="RMS",
-                        description="Photometric repeatability rms for each star.",
-                    ),
-                    "count": Datum(
-                        photRepeatFrame[(magColumn,"count")].values * u.count,
-                        label="count",
-                        description="Number of detections used to calculate repeatability.",
-                    ),
-                    "mean_mag": Datum(
-                        photRepeatFrame[(magColumn,"magMean")].values * u.mag,
-                        label="mean_mag",
-                        description="Mean magnitude of each star.",
-                    ),
-                }
-                return Struct(
-                    measurement=Measurement("PA1", repeatability, extras=extras)
-                )
-            else:
-                return Struct(measurement=Measurement("PA1", repeatability))
+        okRms = (photRepeatFrame[("count")] > 2)
+        okMeanSNR = (photRepeatFrame['meanSnr']> self.config.meanSNRCut)
+
+        #compute PF1 metric
+        import pdb; pdb.set_trace()
+        if (("residuals" in photRepeatFrame.columns) and ((okRms & okMeanSNR).sum() > self.config.nMinPhotRepeat)):
+            residualArray = (np.concatenate(
+                    photRepeatFrame.loc[(okRms & okMeanSNR), "residuals"].values 
+            ) *u.mag).to(u.mmag)
+            percentileAtPA2 = (
+                100 * np.mean(np.abs(residualArray.value) > pa2_thresh.value) * u.percent
+            )          
+            self.log.info("PF1 = %i percent" % percentileAtPA2.value)
+            return Struct(measurement=Measurement("PF1", percentileAtPA2))
         else:
-            return Struct(measurement=Measurement("PA1", np.nan * u.mmag))
+            return Struct(measurement=Measurement("PF1", np.nan * u.percent))

--- a/python/lsst/faro/measurement/MatchedCatalogTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/MatchedCatalogTableMeasurementTasks.py
@@ -32,6 +32,8 @@ import numpy as np
 __all__ = (
     "PA1TableConfig",
     "PA1TableTask",
+    "PF1TableTask",
+    "PF1TableTask",
 )
 class PA1TableConfig(MeasurementTaskConfig):
     """Config fields for the PA1 photometric repeatability metric.
@@ -61,7 +63,6 @@ class PA1TableConfig(MeasurementTaskConfig):
                  "dec": "coord_dec",
                  "flux": "psfFlux",
                  "fluxErr":"psfFluxErr",
-                 "fluxFlag":"psfFluxFlag",
                  "objectID":"obj_index",
                  }
     )
@@ -98,7 +99,7 @@ class PA1TableTask(Task):
         # filter catalog        
         catalog = selectors.applySelectors(catalog,
                                            self.config.selectorActions,
-                                           currentBands=currentBands)
+                                           currentBands=None)
         
         objectidColumn=self.config._getColumnName("objectID", currentBands)
         fluxColumn=self.config._getColumnName("flux", currentBands)
@@ -226,7 +227,7 @@ class PF1TableTask(Task):
         # filter catalog        
         catalog = selectors.applySelectors(catalog,
                                            self.config.selectorActions,
-                                           currentBands=currentBands)
+                                           currentBands=None)
         
         objectidColumn=self.config._getColumnName("objectID", currentBands)
         fluxColumn=self.config._getColumnName("flux", currentBands)

--- a/python/lsst/faro/measurement/MatchedCatalogTableMeasurementTasks.py
+++ b/python/lsst/faro/measurement/MatchedCatalogTableMeasurementTasks.py
@@ -1,0 +1,168 @@
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from lsst.pex.config import Field, DictField
+from lsst.pipe.base import Struct, Task
+from lsst.verify import Measurement, Datum
+
+from lsst.faro.base.ConfigBase import MeasurementTaskConfig
+import lsst.faro.utils.selectors as selectors
+from lsst.faro.utils.tex_table import calculateTEx
+
+import astropy.units as u
+import numpy as np
+
+__all__ = (
+    "PA1TableConfig",
+    "PA1TableTask",
+)
+class PA1TableConfig(MeasurementTaskConfig):
+    """Config fields for the PA1 photometric repeatability metric.
+    """
+    nMinPhotRepeat = Field(
+        doc="Minimum number of objects required for photometric repeatability.",
+        dtype=int,
+        default=50,
+    )
+    meanSNRCut = Field(
+        doc="Minimum mean Signal to Noise ratio for source to be incuded in PA1",
+        dtype=int,
+        default=50,
+    )
+    writeExtras = Field(
+        doc="Write out the magnitude residuals and rms values for debugging.",
+        dtype=bool,
+        default=False,
+    )
+    columns = DictField(
+        doc="""Columns required for metric calculation. Should be all columns in SourceTable contexts,
+        and columns that do not change name with band in ObjectTable contexts""",
+        keytype=str,
+        itemtype=str,
+        default={"ra": "coord_ra",
+                 "dec": "coord_dec",
+                 "flux": "psfFlux",
+                 "fluxErr":"psfFluxErr",
+                 "objectID":"obj_index",
+                 }
+    )
+    columnsBand = DictField(
+        doc="""Columns required for metric calculation that change with band in ObjectTable contexts""",
+        keytype=str,
+        itemtype=str,
+        default={}
+    ) 
+
+class PA1TableTask(Task):
+    """Class to perform the PA1 calculation on a ForcedSource parquet Object Table. 
+    PA1 is the photometric repeatability metric from an input set of multiple 
+    visits of the same field.
+
+    Parameters
+    ----------
+    None
+
+    Output:
+    ----------
+    PA1 metric with defined configuration.
+    """
+
+    ConfigClass = PA1TableConfig
+    _DefaultName = "PA1TableTask"
+
+    def run(
+        self, metricName, catalog, currentBands, **kwargs
+    ):
+
+        self.log.info("Measuring %s", metricName)
+        
+        # filter catalog
+        # Select bright isolated s/n filter 20 for pre aggregate cuts
+        
+        catalog = selectors.applySelectors(catalog,
+                                           self.config.selectorActions,
+                                           currentBands=currentBands)
+        
+        objectidColumn=self.config._getColumnName("objectID", currentBands)
+        fluxColumn=self.config._getColumnName("flux", currentBands)
+        fluxErrColumn=self.config._getColumnName("fluxErr", currentBands)
+        
+        magColumn=self.config._getColumnName("flux", currentBands).replace("Flux","Mag")
+        mags=(catalog.loc[:,fluxColumn].values*u.nJy).to(u.ABmag).value
+        catalog=catalog.assign(**{magColumn:mags})
+        
+        # compute aggregated values
+        photRepeatFrame=catalog.groupby(
+                                        objectidColumn
+                                    ).aggregate(
+                                            {magColumn:[
+                                                np.nanstd,
+                                                np.count_nonzero,
+                                                np.mean
+                                            ]
+                                        }
+                                    ).rename(
+                                        columns={
+                                            'nanstd': 'rms',
+                                            'count_nonzero':'count',
+                                            "mean":"magMean"
+                                        }
+                                    )
+        photRepeatFrame.loc[:,"meanSnr"]=catalog.groupby(
+                                                   objectidColumn
+                                                ).apply(
+                                                    lambda row: np.mean(row[fluxColumn]/row[fluxErrColumn])
+                                                    )
+                                  
+        photRepeatFrame.loc[:,"residuals"]=catalog.groupby(
+                                                    objectidColumn
+                                                )[magColumn].apply(lambda x:np.array(x-np.mean(x)))
+        okRms=(photRepeatFrame[(magColumn,"count")] > 2)
+        okMeanSNR=(photRepeatFrame['meanSnr']> self.config.meanSNRCut)
+
+        #compute pa1 metric          
+        repeatability=(np.median(photRepeatFrame.loc[okRms & okMeanSNR,(magColumn,"rms")])*u.mag).to(u.mmag)
+        self.log.info("Median rms = %i mmag" % repeatability.value)
+        if ((magColumn, "magMean") in photRepeatFrame.columns) and (okRms & okMeanSNR).sum() > self.config.nMinPhotRepeat:
+            if self.config.writeExtras:
+                extras = {
+                    "rms": Datum(
+                        (photRepeatFrame[(magColumn,"rms")].values*u.mag).to(u.mmag),
+                        label="RMS",
+                        description="Photometric repeatability rms for each star.",
+                    ),
+                    "count": Datum(
+                        photRepeatFrame[(magColumn,"count")].values * u.count,
+                        label="count",
+                        description="Number of detections used to calculate repeatability.",
+                    ),
+                    "mean_mag": Datum(
+                        photRepeatFrame[(magColumn,"magMean")].values * u.mag,
+                        label="mean_mag",
+                        description="Mean magnitude of each star.",
+                    ),
+                }
+                return Struct(
+                    measurement=Measurement("PA1", repeatability, extras=extras)
+                )
+            else:
+                return Struct(measurement=Measurement("PA1", repeatability))
+        else:
+            return Struct(measurement=Measurement("PA1", np.nan * u.mmag))

--- a/python/lsst/faro/utils/phot_repeat_table.py
+++ b/python/lsst/faro/utils/phot_repeat_table.py
@@ -20,10 +20,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-import pandas as pd
 import astropy.units as u
 
 __all__ = ("calcPhotRepeatTable")
+
 
 def calcPhotRepeatTable(catalog,
                         objectidColumn,
@@ -41,7 +41,7 @@ def calcPhotRepeatTable(catalog,
     fluxColumn : `pandas.DataFrame` schema key
         column name for flux mesurements
     fluxErrColumn : `pandas.DataFrame` schema key
-        column name for error on flux meausrements 
+        column name for error on flux meausrements
     residuals: boolean controling whether residuals should be returned in output
 
     Returns
@@ -58,33 +58,27 @@ def calcPhotRepeatTable(catalog,
         - ``residuals``:  array for each input source,
           containing the magnitude residuals, in mag, with respect to ``magMean``.
     """
-    magColumn=fluxColumn.replace("Flux","Mag")
-    mags=(catalog.loc[:,fluxColumn].values*u.nJy).to(u.ABmag).value
-    catalog=catalog.assign(**{magColumn:mags})
-    photRepeatFrame=catalog.groupby(
-                                        objectidColumn
-                                    ).aggregate(
-                                            {magColumn:[
-                                                np.nanstd,
-                                                np.count_nonzero,
-                                                np.mean
-                                            ]
-                                        }
-                                    ).rename(
-                                        columns={
-                                            'nanstd': 'rms',
-                                            'count_nonzero':'count',
-                                            "mean":"magMean"
-                                        }
-                                    )
-    photRepeatFrame.columns=photRepeatFrame.columns.get_level_values(1)
-    photRepeatFrame.loc[:,"meanSnr"]=catalog.groupby(
-                                                objectidColumn
-                                            ).apply(
-                                                lambda row: np.mean(row[fluxColumn]/row[fluxErrColumn])
-                                                )
-    if residuals:                            
-        photRepeatFrame.loc[:,"residuals"]=catalog.groupby(
-                                                objectidColumn
-                                            )[magColumn].apply(lambda x:np.array(x-np.mean(x)))
-    return photRepeatFrame    
+    magColumn = fluxColumn.replace("Flux", "Mag")
+    mags = (catalog.loc[:, fluxColumn].values*u.nJy).to(u.ABmag).value
+    catalog = catalog.assign(**{magColumn: mags})
+
+    photRepeatFrame = catalog.groupby(
+        objectidColumn
+    ).aggregate({magColumn: [np.nanstd, np.count_nonzero, np.mean]}).rename(
+        columns={
+            'nanstd': 'rms',
+            'count_nonzero': 'count',
+            "mean": "magMean"
+        }
+    )
+    photRepeatFrame.columns = photRepeatFrame.columns.get_level_values(1)
+    photRepeatFrame.loc[:, "meanSnr"] = catalog.groupby(
+        objectidColumn
+    ).apply(
+        lambda row: np.mean(row[fluxColumn]/row[fluxErrColumn])
+    )
+    if residuals:
+        photRepeatFrame.loc[:, "residuals"] = catalog.groupby(
+            objectidColumn
+        )[magColumn].apply(lambda x: np.array(x-np.mean(x)))
+    return photRepeatFrame

--- a/python/lsst/faro/utils/phot_repeat_table.py
+++ b/python/lsst/faro/utils/phot_repeat_table.py
@@ -1,0 +1,90 @@
+# This file is part of faro.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+import pandas as pd
+import astropy.units as u
+
+__all__ = ("calcPhotRepeatTable")
+
+def calcPhotRepeatTable(catalog,
+                        objectidColumn,
+                        fluxColumn,
+                        fluxErrColumn,
+                        residuals=False):
+    """Calculate the photometric repeatability of a set of measurements.
+
+    Parameters
+    ----------
+    catalog : `pandas.DataFrame` of sources matched between visits using
+              objectidColumn as an index
+    objectidColumn : `pandas.DataFrame` schema key
+        column name for matched object Id column
+    fluxColumn : `pandas.DataFrame` schema key
+        column name for flux mesurements
+    fluxErrColumn : `pandas.DataFrame` schema key
+        column name for error on flux meausrements 
+    residuals: boolean controling whether residuals should be returned in output
+
+    Returns
+    -------
+    photRepeatFrame : `pandas.DataFrame`
+        Repeatability statistics and ancillary quantities calculated from the
+        input catalog. Fields are:
+        - ``count``: array of number of nonzero magnitude measurements for each
+          input source.
+        - ``magMean``: `~astropy.unit.Quantity` array of mean magnitudes, in mag,
+          for each input source.
+        - ``rms``: `~astropy.unit.Quantity` array of RMS photometric repeatability
+          about the mean, in mmag, for each input source.
+        - ``residuals``:  array for each input source,
+          containing the magnitude residuals, in mag, with respect to ``magMean``.
+    """
+    magColumn=fluxColumn.replace("Flux","Mag")
+    mags=(catalog.loc[:,fluxColumn].values*u.nJy).to(u.ABmag).value
+    catalog=catalog.assign(**{magColumn:mags})
+    photRepeatFrame=catalog.groupby(
+                                        objectidColumn
+                                    ).aggregate(
+                                            {magColumn:[
+                                                np.nanstd,
+                                                np.count_nonzero,
+                                                np.mean
+                                            ]
+                                        }
+                                    ).rename(
+                                        columns={
+                                            'nanstd': 'rms',
+                                            'count_nonzero':'count',
+                                            "mean":"magMean"
+                                        }
+                                    )
+    photRepeatFrame.columns=photRepeatFrame.columns.get_level_values(1)
+    photRepeatFrame.loc[:,"meanSnr"]=catalog.groupby(
+                                                objectidColumn
+                                            ).apply(
+                                                lambda row: np.mean(row[fluxColumn]/row[fluxErrColumn])
+                                                )
+    if residuals:                            
+        photRepeatFrame.loc[:,"residuals"]=catalog.groupby(
+                                                objectidColumn
+                                            )[magColumn].apply(lambda x:np.array(x-np.mean(x)))
+    return photRepeatFrame    


### PR DESCRIPTION
This ticket contains measurement tasks for photometric repeatability metrics PA1 and PF1. 
They have been updated to use parquet format files that have been previously matched using the `isolatedStarAssociationTask`