### PR TITLE
DM-33497: Remove calls to registry.expandDataId

### DIFF
--- a/python/lsst/faro/base/MatchedCatalogBase.py
+++ b/python/lsst/faro/base/MatchedCatalogBase.py
@@ -240,9 +240,7 @@ class MatchedBaseTask(pipeBase.PipelineTask):
         box, wcs = self.get_box_wcs(skymap, oid)
         # Cast to float to handle fractional pixels
         box = geom.Box2D(box)
-        inputs["dataIds"] = [
-            butlerQC.registry.expandDataId(el.dataId) for el in inputRefs.sourceCatalogs
-        ]
+        inputs["dataIds"] = [el.dataId for el in inputRefs.sourceCatalogs]
         inputs["wcs"] = wcs
         inputs["box"] = box
         inputs["doApplyExternalSkyWcs"] = self.config.doApplyExternalSkyWcs

--- a/python/lsst/faro/measurement/MatchedCatalogMeasurement.py
+++ b/python/lsst/faro/measurement/MatchedCatalogMeasurement.py
@@ -145,8 +145,8 @@ class PatchMatchedMultiBandMeasurementTask(CatalogMeasurementBaseTask):
         activators in the future.
         """
         try:
-            in_id = butlerQC.registry.expandDataId(inputRefs.matchedCatalogMulti.dataId)
-            out_id = butlerQC.registry.expandDataId(outputRefs.measurement.dataId)
+            in_id = inputRefs.matchedCatalogMulti.dataId
+            out_id = outputRefs.measurement.dataId
             inputs = butlerQC.get(inputRefs)
             inputs["in_id"] = in_id
             inputs["out_id"] = out_id

--- a/python/lsst/faro/measurement/TractMeasurement.py
+++ b/python/lsst/faro/measurement/TractMeasurement.py
@@ -127,9 +127,7 @@ class TractMeasurementTask(CatalogMeasurementBaseTask):
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         inputs = butlerQC.get(inputRefs)
-        inputs["dataIds"] = [
-            butlerQC.registry.expandDataId(cat.dataId) for cat in inputRefs.catalogs
-        ]
+        inputs["dataIds"] = [cat.dataId for cat in inputRefs.catalogs]
         outputs = self.run(**inputs)
         if outputs.measurement is not None:
             butlerQC.put(outputs, outputRefs)

--- a/python/lsst/faro/measurement/VisitMeasurement.py
+++ b/python/lsst/faro/measurement/VisitMeasurement.py
@@ -115,9 +115,7 @@ class VisitMeasurementTask(CatalogMeasurementBaseTask):
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         inputs = butlerQC.get(inputRefs)
-        inputs["dataIds"] = [
-            butlerQC.registry.expandDataId(c.dataId) for c in inputRefs.catalogs
-        ]
+        inputs["dataIds"] = [c.dataId for c in inputRefs.catalogs]
         outputs = self.run(**inputs)
         if outputs.measurement is not None:
             butlerQC.put(outputs, outputRefs)


### PR DESCRIPTION
Recent changes to ButlerQC removed registry attribute, but all DataIds in a quantum are already expanded, so these calls are not needed.