### PR TITLE
DM-39828: Use 'Catalog.__getitem__' instead of 'get' in selectors.

### DIFF
--- a/python/lsst/faro/measurement/example_VisitMeasurementTasks.py
+++ b/python/lsst/faro/measurement/example_VisitMeasurementTasks.py
@@ -35,8 +35,8 @@ class StarFracTask(Task):
         self.log.info("Measuring %s", metricName)
         if not catalog.isContiguous():
             catalog = catalog.copy(deep=True)
-        extended = catalog.get("base_ClassificationExtendedness_value")
-        good_extended = extended[~catalog.get("base_ClassificationExtendedness_flag")]
+        extended = catalog["base_ClassificationExtendedness_value"]
+        good_extended = extended[~catalog["base_ClassificationExtendedness_flag"]]
         n_gals = sum(good_extended)
         frac = 100 * (len(good_extended) - n_gals) / len(good_extended)
         meas = Measurement("starFrac", frac * u.percent)

--- a/python/lsst/faro/utils/coord_util.py
+++ b/python/lsst/faro/utils/coord_util.py
@@ -42,13 +42,14 @@ def averageRaFromCat(cat):
     Parameters
     ----------
     cat : collection
-         Object with .get method for 'coord_ra', 'coord_dec' that returns radians.
+        Object for which ``cat["coord_ra"]`` and ``cat["coord_dec"]`` both
+        return radians.
     Returns
     -------
     ra_mean : `float`
         Mean RA in radians.
     """
-    meanRa, meanDec = averageRaDecFromCat(cat)
+    meanRa, _ = averageRaDecFromCat(cat)
     return meanRa
 
 
@@ -62,13 +63,14 @@ def averageDecFromCat(cat):
     Parameters
     ----------
     cat : collection
-         Object with .get method for 'coord_ra', 'coord_dec' that returns radians.
+        Object for which ``cat["coord_ra"]`` and ``cat["coord_dec"]`` both
+        return radians.
     Returns
     -------
     dec_mean : `float`
         Mean Dec in radians.
     """
-    meanRa, meanDec = averageRaDecFromCat(cat)
+    _, meanDec = averageRaDecFromCat(cat)
     return meanDec
 
 
@@ -78,7 +80,8 @@ def averageRaDecFromCat(cat):
     Parameters
     ----------
     cat : collection
-         Object with .get method for 'coord_ra', 'coord_dec' that returns radians.
+        Object for which ``cat["coord_ra"]`` and ``cat["coord_dec"]`` both
+        return radians.
     Returns
     -------
     ra_mean : `float`
@@ -86,7 +89,7 @@ def averageRaDecFromCat(cat):
     dec_mean : `float`
         Mean Dec in radians.
     """
-    return averageRaDec(cat.get("coord_ra"), cat.get("coord_dec"))
+    return averageRaDec(cat["coord_ra"], cat["coord_dec"])
 
 
 def averageRaDec(ra, dec):

--- a/python/lsst/faro/utils/filtermatches.py
+++ b/python/lsst/faro/utils/filtermatches.py
@@ -61,17 +61,17 @@ def filterMatches(
     def nMatchFilter(cat):
         if len(cat) < nMatchesRequired:
             return False
-        return np.isfinite(cat.get(magKey)).all()
+        return np.isfinite(cat[magKey]).all()
 
     def snrFilter(cat):
         # Note that this also implicitly checks for psfSnr being non-nan.
-        snr = cat.get("base_PsfFlux_snr")
+        snr = cat["base_PsfFlux_snr"]
         (ok0,) = np.where(np.isfinite(snr))
         medianSnr = np.median(snr[ok0])
         return snrMin <= medianSnr and medianSnr <= snrMax
 
     def ptsrcFilter(cat):
-        ext = cat.get("base_ClassificationExtendedness_value")
+        ext = cat["base_ClassificationExtendedness_value"]
         # Keep only objects that are flagged as "not extended" in *ALL* visits,
         # (base_ClassificationExtendedness_value = 1 for extended, 0 for point-like)
         if extended:
@@ -81,17 +81,17 @@ def filterMatches(
 
     def flagFilter(cat):
         if doFlags:
-            flag_sat = cat.get("base_PixelFlags_flag_saturated")
-            flag_cr = cat.get("base_PixelFlags_flag_cr")
-            flag_bad = cat.get("base_PixelFlags_flag_bad")
-            flag_edge = cat.get("base_PixelFlags_flag_edge")
+            flag_sat = cat["base_PixelFlags_flag_saturated"]
+            flag_cr = cat["base_PixelFlags_flag_cr"]
+            flag_bad = cat["base_PixelFlags_flag_bad"]
+            flag_edge = cat["base_PixelFlags_flag_edge"]
             return np.logical_not(np.any([flag_sat, flag_cr, flag_bad, flag_edge]))
         else:
             return True
 
     def isPrimaryFilter(cat):
         if isPrimary:
-            flag_isPrimary = cat.get("detect_isPrimary")
+            flag_isPrimary = cat["detect_isPrimary"]
             return np.all(flag_isPrimary)
         else:
             return True

--- a/python/lsst/faro/utils/matcher.py
+++ b/python/lsst/faro/utils/matcher.py
@@ -202,9 +202,9 @@ def ellipticityFromCat(cat, slot_shape="slot_Shape"):
         Complex ellipticity, real part, imaginary part
     """
     i_xx, i_xy, i_yy = (
-        cat.get(slot_shape + "_xx"),
-        cat.get(slot_shape + "_xy"),
-        cat.get(slot_shape + "_yy"),
+        cat[slot_shape + "_xx"],
+        cat[slot_shape + "_xy"],
+        cat[slot_shape + "_yy"],
     )
     return ellipticity(i_xx, i_xy, i_yy)
 

--- a/python/lsst/faro/utils/separations.py
+++ b/python/lsst/faro/utils/separations.py
@@ -113,7 +113,7 @@ def calcRmsDistances(groupView, annulus, magRange, verbose=False):
     minMag, maxMag = magRange.to(u.mag).value
 
     def magInRange(cat):
-        mag = cat.get("base_PsfFlux_mag")
+        mag = cat["base_PsfFlux_mag"]
         (w,) = np.where(np.isfinite(mag))
         medianMag = np.median(mag[w])
         return minMag <= medianMag and medianMag < maxMag
@@ -122,7 +122,7 @@ def calcRmsDistances(groupView, annulus, magRange, verbose=False):
 
     # List of lists of id, importantValue
     matchKeyOutput = [
-        obj.get(key) for key in importantKeys for obj in groupViewInMagRange.groups
+        obj[key] for key in importantKeys for obj in groupViewInMagRange.groups
     ]
 
     jump = len(groupViewInMagRange)
@@ -206,7 +206,7 @@ def calcSepOutliers(groupView, annulus, magRange, verbose=False):
     minMag, maxMag = magRange.to(u.mag).value
 
     def magInRange(cat):
-        mag = cat.get("base_PsfFlux_mag")
+        mag = cat["base_PsfFlux_mag"]
         (w,) = np.where(np.isfinite(mag))
         medianMag = np.median(mag[w])
         return minMag <= medianMag and medianMag < maxMag
@@ -215,7 +215,7 @@ def calcSepOutliers(groupView, annulus, magRange, verbose=False):
 
     # List of lists of id, importantValue
     matchKeyOutput = [
-        obj.get(key) for key in importantKeys for obj in groupViewInMagRange.groups
+        obj[key] for key in importantKeys for obj in groupViewInMagRange.groups
     ]
 
     jump = len(groupViewInMagRange)
@@ -329,7 +329,7 @@ def calcRmsDistancesVsRef(groupView, refVisit, magRange, band, verbose=False):
     minMag, maxMag = magRange.to(u.mag).value
 
     def magInRange(cat):
-        mag = cat.get("base_PsfFlux_mag")
+        mag = cat["base_PsfFlux_mag"]
         (w,) = np.where(np.isfinite(mag))
         medianMag = np.median(mag[w])
         return minMag <= medianMag and medianMag < maxMag
@@ -341,7 +341,7 @@ def calcRmsDistancesVsRef(groupView, refVisit, magRange, band, verbose=False):
     uniqVisits = set()
     for id in uniqObj:
         for v, f in zip(
-            groupViewInMagRange[id].get("visit"), groupViewInMagRange[id].get("filt")
+            groupViewInMagRange[id]["visit"], groupViewInMagRange[id]["filt"]
         ):
             if f == band:
                 uniqVisits.add(v)
@@ -363,11 +363,11 @@ def calcRmsDistancesVsRef(groupView, refVisit, magRange, band, verbose=False):
         distancesVisit = list()
 
         for obj in uniqObj:
-            visMatch = np.where(groupViewInMagRange[obj].get("visit") == vis)
-            refMatch = np.where(groupViewInMagRange[obj].get("visit") == refVisit)
+            visMatch = np.where(groupViewInMagRange[obj]["visit"] == vis)
+            refMatch = np.where(groupViewInMagRange[obj]["visit"] == refVisit)
 
-            raObj = groupViewInMagRange[obj].get("coord_ra")
-            decObj = groupViewInMagRange[obj].get("coord_dec")
+            raObj = groupViewInMagRange[obj]["coord_ra"]
+            decObj = groupViewInMagRange[obj]["coord_dec"]
 
             # Require it to have a match in both the reference and visit image:
             if np.size(visMatch[0]) > 0 and np.size(refMatch[0]) > 0:

--- a/tests/test_phot_util.py
+++ b/tests/test_phot_util.py
@@ -49,7 +49,7 @@ class PhotUtilTest(unittest.TestCase):
         def nMatchFilter(cat):
             if len(cat) < nMatchesRequired:
                 return False
-            return np.isfinite(cat.get(magKey)).all()
+            return np.isfinite(cat[magKey]).all()
 
         return matches.where(nMatchFilter), magKey
 

--- a/tests/test_tex_util.py
+++ b/tests/test_tex_util.py
@@ -43,7 +43,7 @@ class TEXUtilTest(unittest.TestCase):
         cat_file = 'src_HSC_i_HSC-I_903986_0_31_HSC_runs_ci_hsc_20210407T021858Z.fits'
         cat = SimpleCatalog.readFits(os.path.join(DATADIR, cat_file))
 
-        # selection = np.isfinite(cat.get('e1')) & np.isfinite(cat.get('e2'))
+        # selection = np.isfinite(cat['e1']) & np.isfinite(cat['e2'])
         selection = np.tile(True, len(cat))
 
         return cat.subset(selection).copy(deep=True)


### PR DESCRIPTION
'get' actually invokes the ColumnView method via __getattr__ forwarding, and that's less capable than Catalog.__getitem__ as well as being a pointless forward to ColumnView.__getitem__ that probably never needed to exist.